### PR TITLE
PDF: Feature: Add save button and location picker activity

### DIFF
--- a/pdf/src/main/java/com/vayunmathur/pdf/MainActivity.kt
+++ b/pdf/src/main/java/com/vayunmathur/pdf/MainActivity.kt
@@ -568,8 +568,8 @@ fun PdfViewerScreen(pdfDocument: EditablePdfDocument) {
         topBar = {
             TopAppBar({ Text(stringResource(R.string.pdf_viewer_title)) }, actions = {
                 if (!showSearchBar) {
-                    IconButton({ downloadLauncher.launch(pdfName) }) { IconSave() }
                     IconButton({ showSearchBar = true }) { IconSearch() }
+                    IconButton({ downloadLauncher.launch(pdfName) }) { IconSave() }
                     IconButton({
                         val intent = Intent(Intent.ACTION_SEND)
                         intent.type = "application/pdf"

--- a/pdf/src/main/java/com/vayunmathur/pdf/MainActivity.kt
+++ b/pdf/src/main/java/com/vayunmathur/pdf/MainActivity.kt
@@ -475,6 +475,24 @@ fun PdfViewerScreen(pdfDocument: EditablePdfDocument) {
     val context = LocalContext.current
     val coroutineScope = rememberCoroutineScope()
 
+    val pdfSavedMessage = stringResource(R.string.pdf_saved)
+    val pdfSaveErrorMessage = stringResource(R.string.pdf_save_error)
+    val downloadLauncher = rememberLauncherForActivityResult(ActivityResultContracts.CreateDocument("application/pdf")) { uri ->
+        uri?.let {
+            coroutineScope.launch {
+                try {
+                    context.contentResolver.openFileDescriptor(it, "w")?.use { pfd ->
+                        pdfDocument.createWriteHandle().writeTo(pfd)
+                        Toast.makeText(context, pdfSavedMessage, Toast.LENGTH_SHORT).show()
+                    }
+                } catch (e: Exception) {
+                    Log.e("PdfViewerScreen", "Error saving PDF", e)
+                    Toast.makeText(context, pdfSaveErrorMessage, Toast.LENGTH_SHORT).show()
+                }
+            }
+        }
+    }
+
     var showSearchBar by remember { mutableStateOf(false) }
     var searchResults by remember { mutableStateOf(emptyList<PdfRect>()) }
     var searchIndex by remember(searchResults) { mutableIntStateOf(0) }
@@ -550,6 +568,7 @@ fun PdfViewerScreen(pdfDocument: EditablePdfDocument) {
         topBar = {
             TopAppBar({ Text(stringResource(R.string.pdf_viewer_title)) }, actions = {
                 if (!showSearchBar) {
+                    IconButton({ downloadLauncher.launch(pdfName) }) { IconSave() }
                     IconButton({ showSearchBar = true }) { IconSearch() }
                     IconButton({
                         val intent = Intent(Intent.ACTION_SEND)

--- a/pdf/src/main/res/values-ar/strings.xml
+++ b/pdf/src/main/res/values-ar/strings.xml
@@ -13,4 +13,6 @@
     <string name="capture_pdf_title">التقاط PDF</string>
     <string name="request_camera_permission">طلب إذن الكاميرا</string>
     <string name="upload_image">تحميل صورة</string>
+    <string name="pdf_saved">تم حفظ PDF</string>
+    <string name="pdf_save_error">خطأ في الحفظ</string>
 </resources>

--- a/pdf/src/main/res/values-es/strings.xml
+++ b/pdf/src/main/res/values-es/strings.xml
@@ -13,4 +13,6 @@
     <string name="capture_pdf_title">Capturar PDF</string>
     <string name="request_camera_permission">Solicitar permiso de cámara</string>
     <string name="upload_image">Subir imagen</string>
+    <string name="pdf_saved">PDF guardado</string>
+    <string name="pdf_save_error">Error al guardar</string>
 </resources>

--- a/pdf/src/main/res/values-fr/strings.xml
+++ b/pdf/src/main/res/values-fr/strings.xml
@@ -13,4 +13,6 @@
     <string name="capture_pdf_title">Capturer PDF</string>
     <string name="request_camera_permission">Autoriser l\'accès à l\'appareil photo</string>
     <string name="upload_image">Importer image</string>
+    <string name="pdf_saved">PDF enregistré</string>
+    <string name="pdf_save_error">Erreur d’enregistrement</string>
 </resources>

--- a/pdf/src/main/res/values-hi/strings.xml
+++ b/pdf/src/main/res/values-hi/strings.xml
@@ -13,4 +13,6 @@
     <string name="capture_pdf_title">PDF कैप्चर करें</string>
     <string name="request_camera_permission">कैमरा अनुमति मांगें</string>
     <string name="upload_image">इमेज अपलोड करें</string>
+    <string name="pdf_saved">PDF सहेजा गया</string>
+    <string name="pdf_save_error">सहेजने में त्रुटि</string>
 </resources>

--- a/pdf/src/main/res/values-zh-rCN/strings.xml
+++ b/pdf/src/main/res/values-zh-rCN/strings.xml
@@ -13,4 +13,6 @@
     <string name="capture_pdf_title">捕获 PDF</string>
     <string name="request_camera_permission">请求相机权限</string>
     <string name="upload_image">上传图片</string>
+    <string name="pdf_saved">PDF 已保存</string>
+    <string name="pdf_save_error">保存失败</string>
 </resources>

--- a/pdf/src/main/res/values/strings.xml
+++ b/pdf/src/main/res/values/strings.xml
@@ -13,4 +13,6 @@
     <string name="capture_pdf_title">Capture PDF</string>
     <string name="request_camera_permission">Request Camera Permission</string>
     <string name="upload_image">Upload Image</string>
+    <string name="pdf_saved">PDF saved successfully</string>
+    <string name="pdf_save_error">Error saving PDF</string>
 </resources>


### PR DESCRIPTION
Suggestion for a PDF saving functionality. This function exists in e.g. Google Drive PDF viewer and Firefox on Android as "Download".

Since I (and maybe others) use the PDF Viewer not only from file manager, but also from other apps (e.g. to open email attachments, documents in banking apps, etc), the viewed file is sometimes not saved in user storage yet. For this, I added the save button and a launched activity to save files so they persist in the user's download, documents or other folder.
The save button also allows easy copying of a file by using it multiple times.

What it does:

- User clicks save button in the TopAppBar
- System file saving dialog is opened
- User can select location and file name of the file
- File is saved/"downloaded" to the specified location