### PR TITLE
Fixed location in findfamily - tidied UI

### DIFF
--- a/findfamily/src/main/java/com/vayunmathur/findfamily/MainActivity.kt
+++ b/findfamily/src/main/java/com/vayunmathur/findfamily/MainActivity.kt
@@ -52,6 +52,7 @@ import com.vayunmathur.findfamily.ui.UserPage
 import com.vayunmathur.findfamily.ui.WaypointEditPage
 import com.vayunmathur.findfamily.ui.dialogs.AddLinkDialog
 import com.vayunmathur.findfamily.ui.dialogs.AddPersonDialog
+import com.vayunmathur.findfamily.ui.SettingsPage
 import com.vayunmathur.library.ui.DynamicTheme
 import com.vayunmathur.library.ui.dialog.DatePickerDialog
 import com.vayunmathur.library.util.DatabaseViewModel
@@ -258,6 +259,9 @@ sealed interface Route: NavKey {
 
     @Serializable
     data object MissingFeaturesDialog: Route
+
+    @Serializable
+    data object Settings: Route
 }
 
 @Composable
@@ -292,6 +296,9 @@ fun Navigation(platform: Platform, viewModel: DatabaseViewModel, showMissingFeat
         }
         entry<Route.MissingFeaturesDialog>(metadata = DialogPage()) {
             MissingFeaturesDialog(backStack)
+        }
+        entry<Route.Settings> {
+            SettingsPage(backStack, viewModel)
         }
     }
 }

--- a/findfamily/src/main/java/com/vayunmathur/findfamily/ui/MainPage.kt
+++ b/findfamily/src/main/java/com/vayunmathur/findfamily/ui/MainPage.kt
@@ -70,6 +70,7 @@ import com.vayunmathur.library.ui.IconClose
 import com.vayunmathur.library.ui.IconCopy
 import com.vayunmathur.library.ui.IconDelete
 import com.vayunmathur.library.ui.IconEdit
+import com.vayunmathur.library.ui.IconSettings
 import com.vayunmathur.library.ui.BackupButtons
 import com.vayunmathur.library.util.BiometricDatabaseHelper
 import com.vayunmathur.library.util.DatabaseViewModel
@@ -116,6 +117,9 @@ fun MainPage(platform: Platform, backStack: NavBackStack<Route>, viewModel: Data
                         dbConfigs = listOf("passwords-db" to pass),
                         extraFiles = emptyList()
                     )
+                    IconButton(onClick = { backStack.add(Route.Settings) }) {
+                        IconSettings()
+                    }
                 }
             )
         },

--- a/findfamily/src/main/java/com/vayunmathur/findfamily/ui/SettingsPage.kt
+++ b/findfamily/src/main/java/com/vayunmathur/findfamily/ui/SettingsPage.kt
@@ -1,0 +1,75 @@
+package com.vayunmathur.findfamily.ui
+
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.ListItem
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Switch
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.vayunmathur.findfamily.R
+import com.vayunmathur.findfamily.Route
+import com.vayunmathur.library.util.DataStoreUtils
+import com.vayunmathur.library.util.NavBackStack
+import com.vayunmathur.library.util.DatabaseViewModel
+import com.vayunmathur.library.ui.IconNavigation
+import kotlinx.coroutines.launch
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun SettingsPage(
+    backStack: NavBackStack<Route>,
+    viewModel: DatabaseViewModel
+) {
+    val context = LocalContext.current
+    val dataStore = DataStoreUtils.getInstance(context)
+    val useNetworkLocation by dataStore.booleanFlow("useNetworkLocation").collectAsState(initial = false)
+    val scope = rememberCoroutineScope()
+    var switchChecked by remember(useNetworkLocation) { mutableStateOf(useNetworkLocation) }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text(stringResource(R.string.settings)) },
+                navigationIcon = { IconNavigation(backStack) }
+            )
+        }
+    ) { paddingValues ->
+        LazyColumn(
+            modifier = Modifier.fillMaxSize().padding(paddingValues)
+        ) {
+            item {
+                ListItem(
+                    headlineContent = { Text(stringResource(R.string.settings_use_network_location)) },
+                    supportingContent = { Text(stringResource(R.string.settings_use_network_location_desc)) },
+                    trailingContent = {
+                        Switch(
+                            checked = switchChecked,
+                            onCheckedChange = { enabled ->
+                                switchChecked = enabled
+                                scope.launch {
+                                    dataStore.setBoolean("useNetworkLocation", enabled)
+                                }
+                            }
+                        )
+                    }
+                )
+                HorizontalDivider()
+            }
+        }
+    }
+}

--- a/findfamily/src/main/java/com/vayunmathur/findfamily/ui/SettingsPage.kt
+++ b/findfamily/src/main/java/com/vayunmathur/findfamily/ui/SettingsPage.kt
@@ -37,9 +37,9 @@ fun SettingsPage(
 ) {
     val context = LocalContext.current
     val dataStore = DataStoreUtils.getInstance(context)
-    val useNetworkLocation by dataStore.booleanFlow("useNetworkLocation").collectAsState(initial = false)
+    val useGpsOnly by dataStore.booleanFlow("useGpsOnly").collectAsState(initial = false)
     val scope = rememberCoroutineScope()
-    var switchChecked by remember(useNetworkLocation) { mutableStateOf(useNetworkLocation) }
+    var switchChecked by remember(useGpsOnly) { mutableStateOf(useGpsOnly) }
 
     Scaffold(
         topBar = {
@@ -54,15 +54,15 @@ fun SettingsPage(
         ) {
             item {
                 ListItem(
-                    headlineContent = { Text(stringResource(R.string.settings_use_network_location)) },
-                    supportingContent = { Text(stringResource(R.string.settings_use_network_location_desc)) },
+                    headlineContent = { Text(stringResource(R.string.settings_use_gps_only)) },
+                    supportingContent = { Text(stringResource(R.string.settings_use_gps_only_desc)) },
                     trailingContent = {
                         Switch(
                             checked = switchChecked,
                             onCheckedChange = { enabled ->
                                 switchChecked = enabled
                                 scope.launch {
-                                    dataStore.setBoolean("useNetworkLocation", enabled)
+                                    dataStore.setBoolean("useGpsOnly", enabled)
                                 }
                             }
                         )

--- a/findfamily/src/main/java/com/vayunmathur/findfamily/util/LocationTrackingService.kt
+++ b/findfamily/src/main/java/com/vayunmathur/findfamily/util/LocationTrackingService.kt
@@ -74,6 +74,7 @@ class LocationTrackingService : Service() {
         )
         println(locationValue)
         CoroutineScope(Dispatchers.IO).launch {
+            viewModel.upsertAsync(locationValue)
             Networking.ensureUserExists()
             println(users)
             users.forEach { user ->
@@ -187,17 +188,31 @@ class LocationTrackingService : Service() {
 
         bm = getSystemService(BATTERY_SERVICE) as BatteryManager
         locationManager = getSystemService(LOCATION_SERVICE) as LocationManager
+        val dataStore = DataStoreUtils.getInstance(this@LocationTrackingService)
+        val useNetworkLocation = dataStore.getBoolean("useNetworkLocation", false)
 
         try {
-            // Request GPS updates
-            locationManager.requestLocationUpdates(
-                LocationManager.NETWORK_PROVIDER,
-                10_000L, // 30 seconds
-                0f,   // regardless of movement
-                locationListener
-            )
+            if (locationManager.isProviderEnabled(LocationManager.GPS_PROVIDER)) {
+                locationManager.requestLocationUpdates(
+                    LocationManager.GPS_PROVIDER,
+                    10_000L,
+                    0f,
+                    locationListener
+                )
+            }
         } catch (_: SecurityException) {
-            // Handle missing permissions
+        }
+
+        if (useNetworkLocation) {
+            try {
+                locationManager.requestLocationUpdates(
+                    LocationManager.NETWORK_PROVIDER,
+                    10_000L,
+                    0f,
+                    locationListener
+                )
+            } catch (_: SecurityException) {
+            }
         }
     }
 

--- a/findfamily/src/main/java/com/vayunmathur/findfamily/util/LocationTrackingService.kt
+++ b/findfamily/src/main/java/com/vayunmathur/findfamily/util/LocationTrackingService.kt
@@ -189,21 +189,21 @@ class LocationTrackingService : Service() {
         bm = getSystemService(BATTERY_SERVICE) as BatteryManager
         locationManager = getSystemService(LOCATION_SERVICE) as LocationManager
         val dataStore = DataStoreUtils.getInstance(this@LocationTrackingService)
-        val useNetworkLocation = dataStore.getBoolean("useNetworkLocation", false)
+        val useGpsOnly = dataStore.getBoolean("useGpsOnly", false)
 
-        try {
-            if (locationManager.isProviderEnabled(LocationManager.GPS_PROVIDER)) {
-                locationManager.requestLocationUpdates(
-                    LocationManager.GPS_PROVIDER,
-                    10_000L,
-                    0f,
-                    locationListener
-                )
+        if (useGpsOnly) {
+            try {
+                if (locationManager.isProviderEnabled(LocationManager.GPS_PROVIDER)) {
+                    locationManager.requestLocationUpdates(
+                        LocationManager.GPS_PROVIDER,
+                        10_000L,
+                        0f,
+                        locationListener
+                    )
+                }
+            } catch (_: SecurityException) {
             }
-        } catch (_: SecurityException) {
-        }
-
-        if (useNetworkLocation) {
+        } else {
             try {
                 locationManager.requestLocationUpdates(
                     LocationManager.NETWORK_PROVIDER,

--- a/findfamily/src/main/res/values/strings.xml
+++ b/findfamily/src/main/res/values/strings.xml
@@ -118,6 +118,6 @@
 
     <!-- Settings -->
     <string name="settings">Settings</string>
-    <string name="settings_use_network_location">Use Network Location</string>
-    <string name="settings_use_network_location_desc">Allow network-based location as fallback when GPS is unavailable</string>
+    <string name="settings_use_gps_only">Use GPS Only</string>
+    <string name="settings_use_gps_only_desc">Use precise GPS location instead of network location. Uses more battery but provides accurate location on graphene os.</string>
 </resources>

--- a/findfamily/src/main/res/values/strings.xml
+++ b/findfamily/src/main/res/values/strings.xml
@@ -115,4 +115,9 @@
     <!-- Missing features screen -->
     <string name="missing_features_title">Required Features Disabled</string>
     <string name="missing_features_explanation">FindFamily requires Network Location and a Geocoder to function correctly. Please ensure Google Play Services or an equivalent is installed and that Network Location is enabled in your device settings.</string>
+
+    <!-- Settings -->
+    <string name="settings">Settings</string>
+    <string name="settings_use_network_location">Use Network Location</string>
+    <string name="settings_use_network_location_desc">Allow network-based location as fallback when GPS is unavailable</string>
 </resources>

--- a/findfamily/src/main/res/values/strings.xml
+++ b/findfamily/src/main/res/values/strings.xml
@@ -114,7 +114,7 @@
 
     <!-- Missing features screen -->
     <string name="missing_features_title">Required Features Disabled</string>
-    <string name="missing_features_explanation">FindFamily requires Network Location and a Geocoder to function correctly. Please ensure Google Play Services or an equivalent is installed and that Network Location is enabled in your device settings.</string>
+    <string name="missing_features_explanation">FindFamily requires Network Location and a Geocoder to function correctly. You must enable them to continue.</string>
 
     <!-- Settings -->
     <string name="settings">Settings</string>

--- a/findfamily/src/main/res/values/strings.xml
+++ b/findfamily/src/main/res/values/strings.xml
@@ -119,5 +119,5 @@
     <!-- Settings -->
     <string name="settings">Settings</string>
     <string name="settings_use_gps_only">Use GPS Only</string>
-    <string name="settings_use_gps_only_desc">Use precise GPS location instead of network location. Uses more battery but provides accurate location on graphene os.</string>
+    <string name="settings_use_gps_only_desc">Use precise GPS location instead of network location. Provides more accurate location, but will increase battery usage.</string>
 </resources>


### PR DESCRIPTION
I changed the default location provider to GPS instead of network. it now works properly with Graphene OS, rather than only displaying random approximate locations. this app really needs gps, not network based approximations. I added a settings menu and included an option to enable network location in case the user isnt on graphene and want's that back.