### PR TITLE
refine tracking service

### DIFF
--- a/findfamily/build.gradle.kts
+++ b/findfamily/build.gradle.kts
@@ -7,14 +7,6 @@ android {
     defaultConfig {
         applicationId = "com.vayunmathur.findfamily"
     }
-
-    buildTypes {
-        debug {
-            applicationIdSuffix = ".debug"
-            versionNameSuffix = "-debug"
-            isMinifyEnabled = false
-        }
-    }
 }
 
 dependencies {

--- a/findfamily/build.gradle.kts
+++ b/findfamily/build.gradle.kts
@@ -7,6 +7,14 @@ android {
     defaultConfig {
         applicationId = "com.vayunmathur.findfamily"
     }
+
+    buildTypes {
+        debug {
+            applicationIdSuffix = ".debug"
+            versionNameSuffix = "-debug"
+            isMinifyEnabled = false
+        }
+    }
 }
 
 dependencies {

--- a/findfamily/src/main/AndroidManifest.xml
+++ b/findfamily/src/main/AndroidManifest.xml
@@ -9,7 +9,6 @@
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
-    <uses-permission android:name="android.permission.ACCESS_BACKGROUND_LOCATION" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_LOCATION" />
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />

--- a/findfamily/src/main/java/com/vayunmathur/findfamily/MainActivity.kt
+++ b/findfamily/src/main/java/com/vayunmathur/findfamily/MainActivity.kt
@@ -80,9 +80,16 @@ class MainActivity : ComponentActivity() {
             DynamicTheme {
                 val context = LocalContext.current
                 val foregroundPermission = Manifest.permission.ACCESS_FINE_LOCATION
+                val notificationPermission = Manifest.permission.POST_NOTIFICATIONS
 
                 var hasForeground by remember {
                     mutableStateOf(ContextCompat.checkSelfPermission(context, foregroundPermission) == PackageManager.PERMISSION_GRANTED)
+                }
+                var hasNotification by remember {
+                    mutableStateOf(
+                        android.os.Build.VERSION.SDK_INT < android.os.Build.VERSION_CODES.TIRAMISU ||
+                        ContextCompat.checkSelfPermission(context, notificationPermission) == PackageManager.PERMISSION_GRANTED
+                    )
                 }
 
                 val lifecycleOwner = LocalLifecycleOwner.current
@@ -93,15 +100,23 @@ class MainActivity : ComponentActivity() {
                                 context,
                                 foregroundPermission
                             ) == PackageManager.PERMISSION_GRANTED
+                            hasNotification = android.os.Build.VERSION.SDK_INT < android.os.Build.VERSION_CODES.TIRAMISU ||
+                                ContextCompat.checkSelfPermission(
+                                    context,
+                                    notificationPermission
+                                ) == PackageManager.PERMISSION_GRANTED
                         }
                     }
                     lifecycleOwner.lifecycle.addObserver(observer)
                     onDispose { lifecycleOwner.lifecycle.removeObserver(observer) }
                 }
 
-                if (!hasForeground) {
+                if (!hasForeground || !hasNotification) {
                     NoPermissionsScreen(
-                        onForegroundGranted = { hasForeground = true }
+                        hasForeground = hasForeground,
+                        hasNotification = hasNotification,
+                        onForegroundGranted = { hasForeground = true },
+                        onNotificationGranted = { hasNotification = true }
                     )
                 } else {
                     Main(platform, viewModel)
@@ -139,12 +154,21 @@ val Migration_2_3 = Migration(2, 3) {
 
 @Composable
 fun NoPermissionsScreen(
-    onForegroundGranted: () -> Unit
+    hasForeground: Boolean,
+    hasNotification: Boolean,
+    onForegroundGranted: () -> Unit,
+    onNotificationGranted: () -> Unit
 ) {
     val foregroundLauncher = rememberLauncherForActivityResult(
         ActivityResultContracts.RequestPermission()
     ) { isGranted ->
         if (isGranted) onForegroundGranted()
+    }
+
+    val notificationLauncher = rememberLauncherForActivityResult(
+        ActivityResultContracts.RequestPermission()
+    ) { isGranted ->
+        if (isGranted) onNotificationGranted()
     }
 
     Scaffold { padding ->
@@ -154,9 +178,21 @@ fun NoPermissionsScreen(
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
             Button(
-                onClick = { foregroundLauncher.launch(Manifest.permission.ACCESS_FINE_LOCATION) }
+                onClick = { foregroundLauncher.launch(Manifest.permission.ACCESS_FINE_LOCATION) },
+                enabled = !hasForeground
             ) {
-                Text(stringResource(R.string.permission_grant_location))
+                Text(if (hasForeground) stringResource(R.string.permission_location_granted) else stringResource(R.string.permission_grant_location))
+            }
+
+            Spacer(Modifier.height(16.dp))
+
+            if (hasForeground) {
+                Button(
+                    onClick = { notificationLauncher.launch(Manifest.permission.POST_NOTIFICATIONS) },
+                    enabled = !hasNotification
+                ) {
+                    Text(if (hasNotification) stringResource(R.string.permission_notification_granted) else stringResource(R.string.permission_grant_notification))
+                }
             }
 
             Spacer(Modifier.height(16.dp))

--- a/findfamily/src/main/java/com/vayunmathur/findfamily/MainActivity.kt
+++ b/findfamily/src/main/java/com/vayunmathur/findfamily/MainActivity.kt
@@ -2,6 +2,7 @@ package com.vayunmathur.findfamily
 
 import android.Manifest
 import android.content.Context
+import android.content.Intent
 import android.content.pm.PackageManager
 import android.location.Geocoder
 import android.location.LocationManager
@@ -18,7 +19,6 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Button
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.Surface
@@ -33,7 +33,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.core.content.ContextCompat
 import androidx.lifecycle.Lifecycle
@@ -53,6 +52,7 @@ import com.vayunmathur.findfamily.ui.WaypointEditPage
 import com.vayunmathur.findfamily.ui.dialogs.AddLinkDialog
 import com.vayunmathur.findfamily.ui.dialogs.AddPersonDialog
 import com.vayunmathur.findfamily.ui.SettingsPage
+import com.vayunmathur.findfamily.util.LocationTrackingService
 import com.vayunmathur.library.ui.DynamicTheme
 import com.vayunmathur.library.ui.dialog.DatePickerDialog
 import com.vayunmathur.library.util.DatabaseViewModel
@@ -80,16 +80,11 @@ class MainActivity : ComponentActivity() {
             DynamicTheme {
                 val context = LocalContext.current
                 val foregroundPermission = Manifest.permission.ACCESS_FINE_LOCATION
-                val backgroundPermission = Manifest.permission.ACCESS_BACKGROUND_LOCATION
 
                 var hasForeground by remember {
                     mutableStateOf(ContextCompat.checkSelfPermission(context, foregroundPermission) == PackageManager.PERMISSION_GRANTED)
                 }
-                var hasBackground by remember {
-                    mutableStateOf(ContextCompat.checkSelfPermission(context, backgroundPermission) == PackageManager.PERMISSION_GRANTED)
-                }
 
-                // Automatically re-check when returning from System Settings
                 val lifecycleOwner = LocalLifecycleOwner.current
                 DisposableEffect(lifecycleOwner) {
                     val observer = LifecycleEventObserver { _, event ->
@@ -98,22 +93,15 @@ class MainActivity : ComponentActivity() {
                                 context,
                                 foregroundPermission
                             ) == PackageManager.PERMISSION_GRANTED
-                            hasBackground = ContextCompat.checkSelfPermission(
-                                context,
-                                backgroundPermission
-                            ) == PackageManager.PERMISSION_GRANTED
                         }
                     }
                     lifecycleOwner.lifecycle.addObserver(observer)
                     onDispose { lifecycleOwner.lifecycle.removeObserver(observer) }
                 }
 
-                if (!hasForeground || !hasBackground) {
+                if (!hasForeground) {
                     NoPermissionsScreen(
-                        hasForeground = hasForeground,
-                        hasBackground = hasBackground,
-                        onForegroundGranted = { hasForeground = true },
-                        onBackgroundGranted = { hasBackground = true }
+                        onForegroundGranted = { hasForeground = true }
                     )
                 } else {
                     Main(platform, viewModel)
@@ -133,6 +121,7 @@ class MainActivity : ComponentActivity() {
 
         LaunchedEffect(Unit) {
             ensureSync(this@MainActivity)
+            context.startForegroundService(Intent(context, LocationTrackingService::class.java))
         }
         Navigation(platform, viewModel, !isNetworkEnabled || !isGeocoderPresent)
     }
@@ -150,23 +139,12 @@ val Migration_2_3 = Migration(2, 3) {
 
 @Composable
 fun NoPermissionsScreen(
-    hasForeground: Boolean,
-    hasBackground: Boolean,
-    onForegroundGranted: () -> Unit,
-    onBackgroundGranted: () -> Unit
+    onForegroundGranted: () -> Unit
 ) {
-    // Launcher for Fine Location
     val foregroundLauncher = rememberLauncherForActivityResult(
         ActivityResultContracts.RequestPermission()
     ) { isGranted ->
         if (isGranted) onForegroundGranted()
-    }
-
-    // Launcher for Background Location (Redirects to Settings)
-    val backgroundLauncher = rememberLauncherForActivityResult(
-        ActivityResultContracts.RequestPermission()
-    ) { isGranted ->
-        if (isGranted) onBackgroundGranted()
     }
 
     Scaffold { padding ->
@@ -175,33 +153,18 @@ fun NoPermissionsScreen(
             verticalArrangement = Arrangement.Center,
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
-            // STEP 1: Fine Location
             Button(
-                onClick = { foregroundLauncher.launch(Manifest.permission.ACCESS_FINE_LOCATION) },
-                enabled = !hasForeground
+                onClick = { foregroundLauncher.launch(Manifest.permission.ACCESS_FINE_LOCATION) }
             ) {
-                Text(if (hasForeground) stringResource(R.string.permission_fine_location_granted) else stringResource(R.string.permission_grant_fine_location))
+                Text(stringResource(R.string.permission_grant_location))
             }
 
             Spacer(Modifier.height(16.dp))
-
-            // STEP 2: Background Location
-            Button(
-                onClick = { backgroundLauncher.launch(Manifest.permission.ACCESS_BACKGROUND_LOCATION) },
-                enabled = hasForeground && !hasBackground
-            ) {
-                val label = if (hasBackground) stringResource(R.string.permission_background_granted) else stringResource(R.string.permission_enable_all_the_time)
-                Text(label)
-            }
-
-            if (hasForeground && !hasBackground) {
-                Text(
-                    text = stringResource(R.string.permission_background_explanation),
-                    textAlign = TextAlign.Center,
-                    style = MaterialTheme.typography.bodySmall,
-                    modifier = Modifier.padding(horizontal = 32.dp, vertical = 8.dp)
-                )
-            }
+            Text(
+                text = stringResource(R.string.permission_location_explanation),
+                style = androidx.compose.material3.MaterialTheme.typography.bodySmall,
+                modifier = Modifier.padding(horizontal = 32.dp)
+            )
         }
     }
 }
@@ -209,8 +172,8 @@ fun NoPermissionsScreen(
 @Composable
 fun MissingFeaturesDialog(backStack: NavBackStack<Route>) {
     Surface(
-        shape = MaterialTheme.shapes.medium,
-        color = MaterialTheme.colorScheme.surface,
+        shape = androidx.compose.material3.MaterialTheme.shapes.medium,
+        color = androidx.compose.material3.MaterialTheme.colorScheme.surface,
         modifier = Modifier.padding(16.dp)
     ) {
         Column(
@@ -220,14 +183,12 @@ fun MissingFeaturesDialog(backStack: NavBackStack<Route>) {
         ) {
             Text(
                 text = stringResource(R.string.missing_features_title),
-                style = MaterialTheme.typography.headlineSmall,
-                textAlign = TextAlign.Center
+                style = androidx.compose.material3.MaterialTheme.typography.headlineSmall
             )
             Spacer(Modifier.height(16.dp))
             Text(
                 text = stringResource(R.string.missing_features_explanation),
-                textAlign = TextAlign.Center,
-                style = MaterialTheme.typography.bodyMedium
+                style = androidx.compose.material3.MaterialTheme.typography.bodyMedium
             )
             Spacer(Modifier.height(24.dp))
             Button(onClick = { backStack.pop() }) {

--- a/findfamily/src/main/java/com/vayunmathur/findfamily/ui/SettingsPage.kt
+++ b/findfamily/src/main/java/com/vayunmathur/findfamily/ui/SettingsPage.kt
@@ -1,20 +1,53 @@
 package com.vayunmathur.findfamily.ui
 
+import android.content.Context
+import android.content.Intent
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.plus
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.selection.selectable
+import androidx.compose.foundation.selection.selectableGroup
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ListItem
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.RadioButton
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
 import com.vayunmathur.findfamily.R
 import com.vayunmathur.findfamily.Route
-import com.vayunmathur.library.util.NavBackStack
-import com.vayunmathur.library.util.DatabaseViewModel
+import com.vayunmathur.findfamily.util.LocationMode
+import com.vayunmathur.findfamily.util.LocationTrackingService
 import com.vayunmathur.library.ui.IconNavigation
+import com.vayunmathur.library.util.DataStoreUtils
+import com.vayunmathur.library.util.DatabaseViewModel
+import com.vayunmathur.library.util.NavBackStack
+import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -22,6 +55,44 @@ fun SettingsPage(
     backStack: NavBackStack<Route>,
     viewModel: DatabaseViewModel
 ) {
+    val context = LocalContext.current
+    val dataStore = remember { DataStoreUtils.getInstance(context) }
+    val coroutineScope = rememberCoroutineScope()
+
+    var locationMode by remember { mutableStateOf(LocationMode.fromKey(dataStore.getString("location_mode") ?: "balanced")) }
+    var gpsFallbackEnabled by remember { mutableStateOf(dataStore.getBoolean("gps_fallback_enabled", true)) }
+    var smartTrackingEnabled by remember { mutableStateOf(dataStore.getBoolean("smart_tracking_enabled", true)) }
+
+    fun setLocationMode(mode: LocationMode) {
+        locationMode = mode
+        coroutineScope.launch {
+            dataStore.setString("location_mode", mode.key)
+            restartTrackingService(context)
+        }
+    }
+
+    fun setGpsFallbackEnabled(enabled: Boolean) {
+        gpsFallbackEnabled = enabled
+        coroutineScope.launch {
+            dataStore.setBoolean("gps_fallback_enabled", enabled)
+            restartTrackingService(context)
+        }
+    }
+
+    fun setSmartTrackingEnabled(enabled: Boolean) {
+        smartTrackingEnabled = enabled
+        coroutineScope.launch {
+            dataStore.setBoolean("smart_tracking_enabled", enabled)
+            restartTrackingService(context)
+        }
+    }
+
+    val batteryEstimate = when (locationMode) {
+        LocationMode.BATTERY_SAVER -> "1-2%"
+        LocationMode.BALANCED -> "3-5%"
+        LocationMode.HIGH_ACCURACY -> "8-12%"
+    }
+
     Scaffold(
         topBar = {
             TopAppBar(
@@ -31,9 +102,170 @@ fun SettingsPage(
         }
     ) { paddingValues ->
         LazyColumn(
-            modifier = Modifier.fillMaxSize().padding(paddingValues)
+            modifier = Modifier.fillMaxSize(),
+            contentPadding = paddingValues.plus(PaddingValues(16.dp))
         ) {
-            // Settings items can be added here
+            item {
+                SectionHeader(stringResource(R.string.settings_location_section))
+                Spacer(Modifier.height(8.dp))
+            }
+
+            item {
+                Card(
+                    modifier = Modifier.fillMaxWidth(),
+                    colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceContainerLowest)
+                ) {
+                    Column(modifier = Modifier.padding(16.dp)) {
+                        Text(
+                            text = stringResource(R.string.settings_location_mode),
+                            style = MaterialTheme.typography.titleMedium,
+                            fontWeight = FontWeight.SemiBold
+                        )
+                        Text(
+                            text = stringResource(R.string.settings_location_mode_desc),
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            modifier = Modifier.padding(bottom = 12.dp)
+                        )
+
+                        Column(Modifier.selectableGroup()) {
+                            LocationMode.entries.forEach { mode ->
+                                Row(
+                                    modifier = Modifier
+                                        .fillMaxWidth()
+                                        .selectable(
+                                            selected = locationMode == mode,
+                                            onClick = { setLocationMode(mode) },
+                                            role = Role.RadioButton
+                                        )
+                                        .padding(vertical = 4.dp),
+                                    verticalAlignment = Alignment.CenterVertically
+                                ) {
+                                    RadioButton(
+                                        selected = locationMode == mode,
+                                        onClick = { setLocationMode(mode) }
+                                    )
+                                    Spacer(Modifier.width(8.dp))
+                                    Column {
+                                        Text(
+                                            text = when (mode) {
+                                                LocationMode.BATTERY_SAVER -> stringResource(R.string.location_mode_battery_saver)
+                                                LocationMode.BALANCED -> stringResource(R.string.location_mode_balanced)
+                                                LocationMode.HIGH_ACCURACY -> stringResource(R.string.location_mode_high_accuracy)
+                                            },
+                                            style = MaterialTheme.typography.bodyLarge,
+                                            fontWeight = if (locationMode == mode) FontWeight.SemiBold else FontWeight.Normal
+                                        )
+                                        Text(
+                                            text = when (mode) {
+                                                LocationMode.BATTERY_SAVER -> stringResource(R.string.location_mode_battery_saver_desc)
+                                                LocationMode.BALANCED -> stringResource(R.string.location_mode_balanced_desc)
+                                                LocationMode.HIGH_ACCURACY -> stringResource(R.string.location_mode_high_accuracy_desc)
+                                            },
+                                            style = MaterialTheme.typography.bodySmall,
+                                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                                        )
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+                Spacer(Modifier.height(12.dp))
+            }
+
+            item {
+                Card(
+                    modifier = Modifier.fillMaxWidth(),
+                    colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceContainerLowest)
+                ) {
+                    ListItem(
+                        headlineContent = { Text(stringResource(R.string.settings_gps_fallback)) },
+                        supportingContent = {
+                            Text(
+                                text = if (gpsFallbackEnabled)
+                                    stringResource(R.string.settings_gps_fallback_enabled)
+                                else
+                                    stringResource(R.string.settings_gps_fallback_disabled)
+                            )
+                        },
+                        trailingContent = {
+                            Switch(
+                                checked = gpsFallbackEnabled,
+                                onCheckedChange = { setGpsFallbackEnabled(it) }
+                            )
+                        }
+                    )
+                }
+                Spacer(Modifier.height(12.dp))
+            }
+
+            item {
+                Card(
+                    modifier = Modifier.fillMaxWidth(),
+                    colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceContainerLowest)
+                ) {
+                    ListItem(
+                        headlineContent = { Text(stringResource(R.string.settings_smart_tracking)) },
+                        supportingContent = {
+                            Text(
+                                text = if (smartTrackingEnabled)
+                                    stringResource(R.string.settings_smart_tracking_enabled)
+                                else
+                                    stringResource(R.string.settings_smart_tracking_disabled)
+                            )
+                        },
+                        trailingContent = {
+                            Switch(
+                                checked = smartTrackingEnabled,
+                                onCheckedChange = { setSmartTrackingEnabled(it) }
+                            )
+                        }
+                    )
+                }
+                Spacer(Modifier.height(12.dp))
+            }
+
+            item {
+                Card(
+                    modifier = Modifier.fillMaxWidth(),
+                    colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceContainerLow)
+                ) {
+                    Column(modifier = Modifier.padding(16.dp)) {
+                        Text(
+                            text = stringResource(R.string.settings_battery_info),
+                            style = MaterialTheme.typography.titleMedium,
+                            fontWeight = FontWeight.SemiBold
+                        )
+                        Spacer(Modifier.height(8.dp))
+                        Text(
+                            text = stringResource(R.string.settings_battery_info_text, batteryEstimate),
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                    }
+                }
+                Spacer(Modifier.height(80.dp))
+            }
         }
+    }
+}
+
+@Composable
+private fun SectionHeader(text: String) {
+    Text(
+        text = text,
+        style = MaterialTheme.typography.titleLarge,
+        fontWeight = FontWeight.Bold,
+        color = MaterialTheme.colorScheme.primary
+    )
+}
+
+private fun restartTrackingService(context: Context) {
+    try {
+        val intent = Intent(context, LocationTrackingService::class.java)
+        context.stopService(intent)
+        context.startForegroundService(intent)
+    } catch (_: Exception) {
     }
 }

--- a/findfamily/src/main/java/com/vayunmathur/findfamily/util/BootReceiver.kt
+++ b/findfamily/src/main/java/com/vayunmathur/findfamily/util/BootReceiver.kt
@@ -9,7 +9,7 @@ import androidx.core.content.ContextCompat
 class BootReceiver : BroadcastReceiver() {
     override fun onReceive(context: Context, intent: Intent) {
         if (intent.action == Intent.ACTION_BOOT_COMPLETED || intent.action == Intent.ACTION_MY_PACKAGE_REPLACED) {
-            if(ContextCompat.checkSelfPermission(context, Manifest.permission.ACCESS_BACKGROUND_LOCATION) == PackageManager.PERMISSION_GRANTED)
+            if(ContextCompat.checkSelfPermission(context, Manifest.permission.ACCESS_FINE_LOCATION) == PackageManager.PERMISSION_GRANTED)
                 context.startForegroundService(Intent(context, LocationTrackingService::class.java))
         }
     }

--- a/findfamily/src/main/java/com/vayunmathur/findfamily/util/LocationTrackingService.kt
+++ b/findfamily/src/main/java/com/vayunmathur/findfamily/util/LocationTrackingService.kt
@@ -1,4 +1,5 @@
 package com.vayunmathur.findfamily.util
+
 import android.app.Notification
 import android.app.NotificationChannel
 import android.app.NotificationManager
@@ -37,6 +38,7 @@ import com.vayunmathur.library.util.buildDatabase
 import com.vayunmathur.library.util.startRepeatedTask
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.first
@@ -46,9 +48,17 @@ import kotlinx.coroutines.withContext
 import java.util.Locale
 import kotlin.coroutines.resume
 import kotlin.time.Clock
-import kotlin.time.Duration.Companion.days
-import kotlin.time.Duration.Companion.hours
 import kotlin.time.Duration.Companion.minutes
+
+enum class LocationMode(val key: String, val updateIntervalMs: Long, val minDistanceM: Float, val accuracyThresholdM: Float, val usesGps: Boolean) {
+    BATTERY_SAVER("battery_saver", 900_000L, 500f, 500f, false),
+    BALANCED("balanced", 300_000L, 100f, 100f, true),
+    HIGH_ACCURACY("high_accuracy", 30_000L, 10f, 50f, true);
+
+    companion object {
+        fun fromKey(key: String): LocationMode = entries.find { it.key == key } ?: BALANCED
+    }
+}
 
 class LocationTrackingService : Service() {
 
@@ -58,19 +68,58 @@ class LocationTrackingService : Service() {
     private lateinit var waypoints: StateFlow<List<Waypoint>>
     private lateinit var temporaryLinks: StateFlow<List<TemporaryLink>>
     private lateinit var bm: BatteryManager
+    private lateinit var dataStore: DataStoreUtils
+
     private var isGpsRunning = false
+    private var locationMode = LocationMode.BALANCED
+    private var gpsFallbackEnabled = true
+    private var smartTrackingEnabled = true
+
+    private var lastLocation: Location? = null
+    private var lastUpdateTime = 0L
+    private var stationaryCount = 0
+    private var trackingJob: Job? = null
 
     private val networkListener = LocationListener { location ->
-        if (location.accuracy > 100f) {
-            if (!isGpsRunning) startGps()
+        handleLocationUpdate(location, isFromGps = false)
+    }
+
+    private val gpsListener = LocationListener { location ->
+        handleLocationUpdate(location, isFromGps = true)
+    }
+
+    private fun handleLocationUpdate(location: Location, isFromGps: Boolean) {
+        if (smartTrackingEnabled && isStationary(location)) {
+            stationaryCount++
+            if (stationaryCount > 3) return
         } else {
-            if (isGpsRunning) stopGps()
+            stationaryCount = 0
+        }
+
+        val now = System.currentTimeMillis()
+        if (now - lastUpdateTime < locationMode.updateIntervalMs / 10 && !isFromGps) return
+
+        if (!isFromGps && locationMode.usesGps && gpsFallbackEnabled) {
+            if (location.accuracy > locationMode.accuracyThresholdM) {
+                if (!isGpsRunning) startGps()
+            } else {
+                if (isGpsRunning) stopGps()
+                processLocation(location)
+            }
+        } else {
             processLocation(location)
         }
     }
 
-    private val gpsListener = LocationListener { location ->
-        processLocation(location)
+    private fun isStationary(location: Location): Boolean {
+        val last = lastLocation ?: return false
+        val distance = FloatArray(1)
+        android.location.Location.distanceBetween(
+            last.latitude, last.longitude,
+            location.latitude, location.longitude,
+            distance
+        )
+        return distance[0] < 10f
     }
 
     private fun processLocation(location: Location) {
@@ -80,20 +129,21 @@ class LocationTrackingService : Service() {
         val temporaryLinks = temporaryLinks.value
         val userIDs = users.map { it.id }
         val now = Clock.System.now()
-        println(location.accuracy)
+
+        lastLocation = location
+        lastUpdateTime = System.currentTimeMillis()
+
         val locationValue = LocationValue(
             Networking.userid,
             Coord(location.latitude, location.longitude),
-            0f,
+            location.speed,
             location.accuracy,
             Clock.System.now(),
             bm.getIntProperty(BatteryManager.BATTERY_PROPERTY_CAPACITY).toFloat()
         )
-        println(locationValue)
         CoroutineScope(Dispatchers.IO).launch {
             viewModel.upsertAsync(locationValue)
             Networking.ensureUserExists()
-            println(users)
             users.forEach { user ->
                 Networking.publishLocation(locationValue, user)
             }
@@ -105,7 +155,7 @@ class LocationTrackingService : Service() {
             }
             delay(3000)
             Networking.receiveLocations()?.let { locations ->
-                val usersRecieved = locations.map { it.userid }.distinct()
+                val usersRecieved = locations.filter { it.userid != Networking.userid }.map { it.userid }.distinct()
                 val newUsers = usersRecieved.filter { it !in userIDs }
                 viewModel.upsertAll(newUsers.map {
                     User(
@@ -121,11 +171,9 @@ class LocationTrackingService : Service() {
                 })
 
                 val locationValues = viewModel.getLatestMap().first()
-                // update the user.locationName
                 users.forEach { user ->
                     val lastLocation = locations.filter { it.userid == user.id }.maxByOrNull { it.timestamp } ?: return@forEach
                     val lastSavedLocation = locationValues[user.id]
-
 
                     if(lastLocation.battery <= 15f && (lastSavedLocation?.battery?:100f) > 15f) {
                         if(user.id != Networking.userid)
@@ -176,6 +224,8 @@ class LocationTrackingService : Service() {
     }
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        loadSettings()
+
         val notification = createNotification()
 
         startForeground(
@@ -186,6 +236,13 @@ class LocationTrackingService : Service() {
 
         startTracking()
         return START_STICKY
+    }
+
+    private fun loadSettings() {
+        dataStore = DataStoreUtils.getInstance(this)
+        locationMode = LocationMode.fromKey(dataStore.getString("location_mode") ?: "balanced")
+        gpsFallbackEnabled = dataStore.getBoolean("gps_fallback_enabled", true)
+        smartTrackingEnabled = dataStore.getBoolean("smart_tracking_enabled", true)
     }
 
     private fun startTracking() {
@@ -201,7 +258,7 @@ class LocationTrackingService : Service() {
             waypoints = viewModel.data<Waypoint>()
             temporaryLinks = viewModel.data<TemporaryLink>()
             Networking.init(viewModel, DataStoreUtils.getInstance(this@LocationTrackingService))
-            
+
             withContext(Dispatchers.Main) {
                 setupLocationUpdates()
             }
@@ -212,15 +269,71 @@ class LocationTrackingService : Service() {
         bm = getSystemService(BATTERY_SERVICE) as BatteryManager
         locationManager = getSystemService(LOCATION_SERVICE) as LocationManager
 
+        stopAllUpdates()
+
+        when (locationMode) {
+            LocationMode.BATTERY_SAVER -> setupBatterySaverTracking()
+            LocationMode.BALANCED -> setupBalancedTracking()
+            LocationMode.HIGH_ACCURACY -> setupHighAccuracyTracking()
+        }
+    }
+
+    private fun setupBatterySaverTracking() {
         try {
             locationManager.requestLocationUpdates(
                 LocationManager.NETWORK_PROVIDER,
-                10_000L,
-                0f,
+                locationMode.updateIntervalMs,
+                locationMode.minDistanceM,
                 networkListener
             )
         } catch (_: SecurityException) {
         }
+    }
+
+    private fun setupBalancedTracking() {
+        try {
+            locationManager.requestLocationUpdates(
+                LocationManager.NETWORK_PROVIDER,
+                locationMode.updateIntervalMs,
+                locationMode.minDistanceM,
+                networkListener
+            )
+        } catch (_: SecurityException) {
+        }
+    }
+
+    private fun setupHighAccuracyTracking() {
+        try {
+            locationManager.requestLocationUpdates(
+                LocationManager.NETWORK_PROVIDER,
+                locationMode.updateIntervalMs,
+                locationMode.minDistanceM,
+                networkListener
+            )
+        } catch (_: SecurityException) {
+        }
+
+        if (gpsFallbackEnabled) {
+            try {
+                if (locationManager.isProviderEnabled(LocationManager.GPS_PROVIDER)) {
+                    locationManager.requestLocationUpdates(
+                        LocationManager.GPS_PROVIDER,
+                        locationMode.updateIntervalMs / 2,
+                        locationMode.minDistanceM / 2,
+                        gpsListener
+                    )
+                    isGpsRunning = true
+                }
+            } catch (_: SecurityException) {
+            }
+        }
+    }
+
+    private fun stopAllUpdates() {
+        locationManager.removeUpdates(networkListener)
+        locationManager.removeUpdates(gpsListener)
+        isGpsRunning = false
+        trackingJob?.cancel()
     }
 
     companion object {
@@ -231,16 +344,14 @@ class LocationTrackingService : Service() {
     }
 
     private fun createNotification(): Notification {
-        // 1. Create the Channel (Required for API 26+)
         val channel = NotificationChannel(
             CHANNEL_ID,
             getString(R.string.notification_channel_location_tracking_name),
-            NotificationManager.IMPORTANCE_LOW // Low importance so it doesn't "pop up" or make noise
+            NotificationManager.IMPORTANCE_LOW
         ).apply {
             description = getString(R.string.notification_channel_location_tracking_desc)
         }
 
-        // 2. Battery Alerts Channel (High Importance for visibility)
         val batteryChannel = NotificationChannel(
             BATTERY_CHANNEL_ID,
             getString(R.string.notification_channel_battery_name),
@@ -249,7 +360,6 @@ class LocationTrackingService : Service() {
             description = getString(R.string.notification_channel_battery_desc)
         }
 
-        // 3. Entry/Exit Channel
         val arrivalChannel = NotificationChannel(
             ENTRY_EXIT_CHANNEL_ID,
             getString(R.string.notification_channel_entry_exit_name),
@@ -258,26 +368,28 @@ class LocationTrackingService : Service() {
             description = getString(R.string.notification_channel_entry_exit_desc)
         }
 
-        // Register all channels
-
         val manager = getSystemService(NOTIFICATION_SERVICE) as NotificationManager
         manager.createNotificationChannels(listOf(channel, batteryChannel, arrivalChannel))
 
-        // 2. Create an Intent to open the app when the notification is clicked
         val pendingIntent = PendingIntent.getActivity(
             this, 0,
             Intent(this, MainActivity::class.java),
-            PendingIntent.FLAG_IMMUTABLE // Required for API 31+
+            PendingIntent.FLAG_IMMUTABLE
         )
 
-        // 3. Build the notification
+        val modeLabel = when (locationMode) {
+            LocationMode.BATTERY_SAVER -> getString(R.string.location_mode_battery_saver)
+            LocationMode.BALANCED -> getString(R.string.location_mode_balanced)
+            LocationMode.HIGH_ACCURACY -> getString(R.string.location_mode_high_accuracy)
+        }
+
         return NotificationCompat.Builder(this, CHANNEL_ID)
             .setContentTitle(getString(R.string.notification_tracking_title))
-            .setContentText(getString(R.string.notification_tracking_text))
-            .setSmallIcon(R.drawable.ic_launcher_foreground) // Ensure this exists in your res/drawable
-            .setOngoing(true) // Makes it persistent
+            .setContentText("$modeLabel • ${getString(R.string.notification_tracking_text)}")
+            .setSmallIcon(R.drawable.ic_launcher_foreground)
+            .setOngoing(true)
             .setContentIntent(pendingIntent)
-            .setForegroundServiceBehavior(Notification.FOREGROUND_SERVICE_IMMEDIATE) // API 31+ specific
+            .setForegroundServiceBehavior(Notification.FOREGROUND_SERVICE_IMMEDIATE)
             .build()
     }
 
@@ -293,11 +405,10 @@ class LocationTrackingService : Service() {
         val notification = NotificationCompat.Builder(this, channelId)
             .setContentTitle(title)
             .setContentText(message)
-            .setSmallIcon(R.drawable.ic_launcher_foreground) // Consider using specific icons for battery/location
+            .setSmallIcon(R.drawable.ic_launcher_foreground)
             .setAutoCancel(true)
             .build()
 
-        // Generate a unique ID so notifications don't overwrite each other
         val notificationId = (System.currentTimeMillis() % Int.MAX_VALUE).toInt()
         manager.notify(notificationId, notification)
     }
@@ -324,10 +435,7 @@ class LocationTrackingService : Service() {
 
     override fun onDestroy() {
         super.onDestroy()
-        // CRITICAL: Stop the hardware sensors
-        locationManager.removeUpdates(networkListener)
-        locationManager.removeUpdates(gpsListener)
-
+        stopAllUpdates()
         stopForeground(STOP_FOREGROUND_REMOVE)
     }
 }
@@ -337,17 +445,11 @@ suspend fun Context.fetchAddress(lat: Double, lng: Double): Address? =
         val geocoder = Geocoder(this, Locale.getDefault())
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-            // Modern Async API (Android 13+)
             geocoder.getFromLocation(lat, lng, 1) { addresses ->
                 val result = addresses.firstOrNull()
-
-                // Use the stable 3-parameter lambda
-                continuation.resume(result) { _, _, _ ->
-                    /* No specific cleanup needed for Address objects */
-                }
+                continuation.resume(result) { _, _, _ -> }
             }
         } else {
-            // Legacy Synchronous (Must be on background thread)
             try {
                 @Suppress("DEPRECATION")
                 val address = geocoder.getFromLocation(lat, lng, 1)?.firstOrNull()
@@ -357,11 +459,7 @@ suspend fun Context.fetchAddress(lat: Double, lng: Double): Address? =
             }
         }
 
-        // Safety: If the calling scope is canceled, stop the continuation
-        continuation.invokeOnCancellation {
-            // Geocoder doesn't support manual cancellation,
-            // but this prevents memory leaks in the listener.
-        }
+        continuation.invokeOnCancellation { }
     }
 
 class ServiceRestartWorker(

--- a/findfamily/src/main/res/values/strings.xml
+++ b/findfamily/src/main/res/values/strings.xml
@@ -20,7 +20,10 @@
 
     <!-- Permission screen -->
     <string name="permission_grant_location">Allow Location Access</string>
-    <string name="permission_location_explanation">FindFamily needs location access to share your position with family. Tracking runs as a persistent notification, similar to other family safety apps.</string>
+    <string name="permission_location_granted">✅ Location Granted</string>
+    <string name="permission_grant_notification">Allow Notifications</string>
+    <string name="permission_notification_granted">✅ Notifications Allowed</string>
+    <string name="permission_location_explanation">FindFamily needs location and notifications to share your position with family. Tracking runs as a persistent notification, similar to other family safety apps.</string>
 
     <!-- MainPage FAB menu -->
     <string name="fab_person">Person</string>

--- a/findfamily/src/main/res/values/strings.xml
+++ b/findfamily/src/main/res/values/strings.xml
@@ -19,11 +19,8 @@
     <string name="notification_exited_waypoint">%1$s has exited %2$s</string>
 
     <!-- Permission screen -->
-    <string name="permission_fine_location_granted">✅ Fine Location Granted</string>
-    <string name="permission_grant_fine_location">1. Grant Fine Location</string>
-    <string name="permission_background_granted">✅ Background Granted</string>
-    <string name="permission_enable_all_the_time">2. Enable \'Allow all the time\'</string>
-    <string name="permission_background_explanation">To enable background tracking, please select \'Allow all the time\' in the next screen.</string>
+    <string name="permission_grant_location">Allow Location Access</string>
+    <string name="permission_location_explanation">FindFamily needs location access to share your position with family. Tracking runs as a persistent notification, similar to other family safety apps.</string>
 
     <!-- MainPage FAB menu -->
     <string name="fab_person">Person</string>
@@ -118,4 +115,44 @@
 
     <!-- Settings -->
     <string name="settings">Settings</string>
+
+    <!-- Location Settings Section -->
+    <string name="settings_location_section">Location</string>
+    <string name="settings_location_mode">Location Mode</string>
+    <string name="settings_location_mode_desc">Balance accuracy and battery life</string>
+
+    <!-- Location Modes -->
+    <string name="location_mode_battery_saver">Battery Saver</string>
+    <string name="location_mode_battery_saver_desc">Cell/Wi-Fi only, updates every 15 min. Best battery life.</string>
+    <string name="location_mode_balanced">Balanced</string>
+    <string name="location_mode_balanced_desc">Network + GPS fallback, updates every 5 min. Recommended.</string>
+    <string name="location_mode_high_accuracy">High Accuracy</string>
+    <string name="location_mode_high_accuracy_desc">GPS + network, frequent updates. Uses more battery.</string>
+
+    <!-- Location Access Level -->
+    <string name="settings_location_access_desc">Location runs as a persistent foreground service (like GrapheneOS sandboxed Play Services)</string>
+
+    <!-- GPS Settings -->
+    <string name="settings_gps_fallback">GPS Fallback</string>
+    <string name="settings_gps_fallback_desc">Use GPS when network location is inaccurate</string>
+    <string name="settings_gps_fallback_enabled">Enabled — activates when accuracy drops below 100m</string>
+    <string name="settings_gps_fallback_disabled">Disabled — relies on network only</string>
+
+    <!-- Update Frequency -->
+    <string name="settings_update_frequency">Update Frequency</string>
+    <string name="settings_update_frequency_desc">How often to send location updates</string>
+    <string name="frequency_real_time">Real-time (~30s)</string>
+    <string name="frequency_frequent">Frequent (~5 min)</string>
+    <string name="frequency_normal">Normal (~15 min)</string>
+    <string name="frequency_saving">Power Saving (~30 min)</string>
+
+    <!-- Smart Tracking -->
+    <string name="settings_smart_tracking">Smart Tracking</string>
+    <string name="settings_smart_tracking_desc">Reduce updates when stationary to save battery</string>
+    <string name="settings_smart_tracking_enabled">Enabled — pauses updates when not moving</string>
+    <string name="settings_smart_tracking_disabled">Disabled — always updating</string>
+
+    <!-- Battery Info -->
+    <string name="settings_battery_info">Battery Impact</string>
+    <string name="settings_battery_info_text">Location tracking uses approximately %1$s battery per day. Select Battery Saver mode for minimal impact, or High Accuracy for best tracking.</string>
 </resources>

--- a/findfamily/src/main/res/values/strings.xml
+++ b/findfamily/src/main/res/values/strings.xml
@@ -138,8 +138,8 @@
     <!-- GPS Settings -->
     <string name="settings_gps_fallback">GPS Fallback</string>
     <string name="settings_gps_fallback_desc">Use GPS when network location is inaccurate</string>
-    <string name="settings_gps_fallback_enabled">Enabled — activates when accuracy drops below 100m</string>
-    <string name="settings_gps_fallback_disabled">Disabled — relies on network only</string>
+    <string name="settings_gps_fallback_enabled">Enabled (activates when accuracy drops below 100m)</string>
+    <string name="settings_gps_fallback_disabled">Disabled (relies on network only)</string>
 
     <!-- Update Frequency -->
     <string name="settings_update_frequency">Update Frequency</string>
@@ -153,7 +153,7 @@
     <string name="settings_smart_tracking">Smart Tracking</string>
     <string name="settings_smart_tracking_desc">Reduce updates when stationary to save battery</string>
     <string name="settings_smart_tracking_enabled">Enabled — pauses updates when not moving</string>
-    <string name="settings_smart_tracking_disabled">Disabled — always updating</string>
+    <string name="settings_smart_tracking_disabled">Disabled (always updating)</string>
 
     <!-- Battery Info -->
     <string name="settings_battery_info">Battery Impact</string>


### PR DESCRIPTION
This pull includes a reworked tracking service that operates in the foreground like other tracking apps, and adds options for location access customization. 

-swapped from "all the time" location access to "while using the app" only, with a silent notification keeping the app in the foreground to fix bug #100. 
<img width="1080" height="694" alt="Screenshot_20260504-171025" src="https://github.com/user-attachments/assets/53de1ec6-b7fd-4905-8faf-7d14827a64da" />


-added options to control location usage to satisfy request #93 
<img width="1080" height="2410" alt="Screenshot_20260504-171657" src="https://github.com/user-attachments/assets/dcc479ff-eddf-477a-b9b0-0fe375dbb6ef" />
