### PR TITLE
pdf: add support for older android versions

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -40,7 +40,7 @@ room = "2.8.4"
 
 # Special Features (PDF, Maps, Health, Crypto)
 biometric = "1.2.0-alpha05"
-pdfViewer = "1.0.0-alpha16"
+pdfViewer = "1.0.0-alpha18"
 glance = "1.1.1"
 connectClient = "1.2.0-alpha04"
 cryptographyCore = "0.6.0"

--- a/pdf/build.gradle.kts
+++ b/pdf/build.gradle.kts
@@ -3,8 +3,8 @@ plugins {
 }
 
 android {
+    compileSdkExtension = 19
     defaultConfig {
-        minSdk = 35
         applicationId = "com.vayunmathur.pdf"
     }
 }

--- a/pdf/src/main/java/com/vayunmathur/pdf/MainActivity.kt
+++ b/pdf/src/main/java/com/vayunmathur/pdf/MainActivity.kt
@@ -8,7 +8,9 @@ import android.graphics.ImageDecoder
 import android.graphics.Matrix
 import android.graphics.pdf.PdfDocument
 import android.net.Uri
+import android.os.Build
 import android.os.Bundle
+import android.os.ext.SdkExtensions
 import android.util.Log
 import android.widget.Toast
 import androidx.activity.ComponentActivity
@@ -114,6 +116,20 @@ import java.io.FileOutputStream
 import java.util.UUID
 import java.util.concurrent.Executors
 
+fun isAdvancedPdfSupported(): Boolean {
+    return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.VANILLA_ICE_CREAM) {
+        // Android 15 (API 35) supports this natively
+        true
+    } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+        // Check if the "R" extension (Android 11+) is at least Level 13
+        // This is where the PDF backport lives
+        SdkExtensions.getExtensionVersion(Build.VERSION_CODES.R) >= 13
+    } else {
+        // Device is older than Android 11
+        false
+    }
+}
+
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -123,6 +139,19 @@ class MainActivity : ComponentActivity() {
         val data: Uri? = intent.data
 
         val pdfLoader = SandboxedPdfLoader(application)
+
+        if(!isAdvancedPdfSupported()) {
+            setContent {
+                DynamicTheme {
+                    Scaffold() { paddingValues ->
+                        Box(Modifier.padding(paddingValues).fillMaxSize()) {
+                            Text(stringResource(R.string.unsupported_version), Modifier.align(Alignment.Center))
+                        }
+                    }
+                }
+            }
+            return
+        }
 
         setContent {
             var data by rememberSaveable { mutableStateOf(data) }

--- a/pdf/src/main/res/values/strings.xml
+++ b/pdf/src/main/res/values/strings.xml
@@ -16,4 +16,5 @@
     <string name="pdf_saved">PDF saved successfully</string>
     <string name="pdf_save_error">Error saving PDF</string>
     <string name="share_pdf">Share PDF</string>
+    <string name="unsupported_version">This app requires either Android 15 or Google Play Services to be fully updated. If you are unable to do either of these, your device is unfortunately unsupported.</string>
 </resources>


### PR DESCRIPTION
This PR adds support for Android 12+

Unfortunately, I cannot test this myself because this uses SDK extensions that the emulators don't support, so I can only merge after somebody downloads the APK linked below and test it on a device with Android 14 or below and confirms here if it works.

[pdf-release.zip](https://github.com/user-attachments/files/27442762/pdf-release.zip)