### PR TITLE
[alchemist] improve UI

### DIFF
--- a/games/alchemist/src/main/java/com/vayunmathur/games/alchemist/MainActivity.kt
+++ b/games/alchemist/src/main/java/com/vayunmathur/games/alchemist/MainActivity.kt
@@ -11,11 +11,15 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import com.vayunmathur.games.alchemist.data.AlchemyItem
 import com.vayunmathur.games.alchemist.ui.HomeScreen
 import com.vayunmathur.games.alchemist.ui.ItemDetailsScreen
+import com.vayunmathur.games.alchemist.ui.UnlockNotification
 import com.vayunmathur.games.alchemist.util.AlchemistViewModel
 import com.vayunmathur.library.ui.DynamicTheme
 import com.vayunmathur.library.util.AchievementsManager
@@ -23,6 +27,9 @@ import com.vayunmathur.library.util.DataStoreUtils
 import com.vayunmathur.library.util.MainNavigation
 import com.vayunmathur.library.util.NavKey
 import com.vayunmathur.library.util.rememberNavBackStack
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.launch
 import kotlinx.serialization.Serializable
 
 class MainActivity : ComponentActivity() {
@@ -56,9 +63,18 @@ fun Navigation(ds: DataStoreUtils, viewModel: AlchemistViewModel) {
     val achievementsManager = rememberAchievementsManager()
     val newAchievement by achievementsManager.newAchievement.collectAsState()
 
+    var showingUnlock by remember { mutableStateOf(false) }
+    var currentUnlocks by remember { mutableStateOf(emptyList<AlchemyItem>()) }
+
     LaunchedEffect(achievementsManager) {
-        achievementsManager.checkExistingAchievements()
+        launch { achievementsManager.checkExistingAchievements() }
         viewModel.bindAchievements(achievementsManager)
+        viewModel.newUnlocksEvent.collectLatest { items ->
+            currentUnlocks = items
+            showingUnlock = true
+            delay(3000)
+            showingUnlock = false
+        }
     }
 
     Box(Modifier.fillMaxSize()) {
@@ -67,7 +83,7 @@ fun Navigation(ds: DataStoreUtils, viewModel: AlchemistViewModel) {
                 HomeScreen(backStack, viewModel, onOpenGameCenter = { backStack.add(Route.GameCenter) })
             }
             entry<Route.ItemDetails> {
-                ItemDetailsScreen(backStack, ds, it.item)
+                ItemDetailsScreen(backStack, ds, viewModel, it.item)
             }
             entry<Route.GameCenter> {
                 com.vayunmathur.library.ui.GameCenterScreen(
@@ -83,6 +99,11 @@ fun Navigation(ds: DataStoreUtils, viewModel: AlchemistViewModel) {
                 achievementsManager.dismissNotification()
             }
         }
+
+        UnlockNotification(
+            unlock = currentUnlocks,
+            showing = showingUnlock
+        )
     }
 }
 

--- a/games/alchemist/src/main/java/com/vayunmathur/games/alchemist/ui/DynamicAlchemyIcon.kt
+++ b/games/alchemist/src/main/java/com/vayunmathur/games/alchemist/ui/DynamicAlchemyIcon.kt
@@ -5,27 +5,30 @@ import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalResources
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
 import com.vayunmathur.games.alchemist.R
 
 @SuppressLint("DiscouragedApi")
 @Composable
-fun DynamicAlchemyIcon(iconId: Long, modifier: Modifier = Modifier) {
+fun DynamicAlchemyIcon(iconId: Long, undiscovered: Boolean = false, modifier: Modifier = Modifier) {
     val context = LocalContext.current
     val resources = LocalResources.current
-    
     // 1. Construct the resource name string (e.g., "icon_001")
     val name = "icon_${iconId.toString().padStart(3, '0')}"
-    
     // 2. Look up the internal Android resource ID
-    val resId = remember(iconId) { 
+    val resId = remember(iconId) {
         val id = resources.getIdentifier(
             name,
             "drawable",
@@ -42,13 +45,36 @@ fun DynamicAlchemyIcon(iconId: Long, modifier: Modifier = Modifier) {
     }
 
     if (resId != 0) {
-        Image(
-            painter = painterResource(id = resId),
-            contentDescription = stringResource(R.string.alchemy_icon_content_description, iconId),
-            modifier = modifier.fillMaxSize()
-        )
+        Box(modifier = modifier.fillMaxSize()) {
+            Image(
+                painter = painterResource(id = resId),
+                contentDescription = stringResource(
+                    R.string.alchemy_icon_content_description,
+                    iconId
+                ),
+                modifier = modifier.fillMaxSize(),
+                colorFilter = if (undiscovered) ColorFilter.tint(
+                    MaterialTheme.colorScheme.onSurface.copy(alpha = 0.5f)
+                ) else null
+            )
+            if (undiscovered) {
+                Text(
+                    text = "?",
+                    modifier = Modifier.align(Alignment.Center),
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.Bold
+                )
+            }
+        }
     } else {
         // Fallback if the icon ID doesn't exist
-        Box(modifier = modifier.fillMaxSize())
+        Box(modifier = modifier.fillMaxSize().background(Color.Gray)) {
+            Text(
+                text = "???",
+                modifier = Modifier.align(Alignment.Center),
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.Bold
+            )
+        }
     }
 }

--- a/games/alchemist/src/main/java/com/vayunmathur/games/alchemist/ui/HomeScreen.kt
+++ b/games/alchemist/src/main/java/com/vayunmathur/games/alchemist/ui/HomeScreen.kt
@@ -1,26 +1,66 @@
 package com.vayunmathur.games.alchemist.ui
 
+import androidx.compose.animation.Crossfade
+import androidx.compose.foundation.background
 import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.gestures.detectDragGestures
-import androidx.compose.foundation.layout.*
-import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.*
-import androidx.compose.runtime.*
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.key
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.layout.positionInWindow
-import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.KeyboardCapitalization
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.compose.ui.zIndex
 import com.vayunmathur.games.alchemist.R
 import com.vayunmathur.games.alchemist.Route
 import com.vayunmathur.games.alchemist.util.AlchemistViewModel
@@ -36,21 +76,41 @@ fun HomeScreen(
     onOpenGameCenter: () -> Unit
 ) {
     val availableItems by viewModel.availableItems.collectAsState()
+    val allItems by viewModel.allItems.collectAsState()
     val activeItems by viewModel.placedElements.collectAsState()
 
-    var screenWidth by remember { mutableFloatStateOf(0f) }
-    var panelWidth by remember { mutableFloatStateOf(0f) }
-    var playAreaOffsetInWindow by remember { mutableStateOf(Offset.Zero) }
+    // --- UI-only filter state (per the plan: dialog/filter visibility stays in compose) ---
+    var activeCustomFilter by remember { mutableStateOf<String?>(null) }
+    var activeFilter by remember { mutableStateOf<String?>(null) }
+    val displayItems by remember(availableItems, activeFilter, activeCustomFilter) {
+        derivedStateOf {
+            availableItems.filter { item ->
+                val filterToApply = activeCustomFilter ?: activeFilter
+                when (filterToApply) {
+                    "A - F" -> item.name.firstOrNull()?.let { it in 'A'..'F' } ?: false
+                    "G - J" -> item.name.firstOrNull()?.let { it in 'G'..'J' } ?: false
+                    "K - Z" -> item.name.firstOrNull()?.let { it in 'K'..'Z' } ?: false
+                    null -> true
+                    else -> item.name.firstOrNull()?.let { it.uppercaseChar().toString() == filterToApply } ?: false
+                }
+            }
+        }
+    }
 
-    // Tracking for the current item being "pulled out" of the sidebar (UI-only).
+    var bottomBarTopInWindow by remember { mutableFloatStateOf(Float.MAX_VALUE) }
+    var playAreaOffsetInWindow by remember { mutableStateOf(Offset.Zero) }
+    var isDraggingBoardItem by remember { mutableStateOf(false) }
+
+    // Tracking for the current item being "pulled out" of the bottom bar
     var draggingInventoryId by remember { mutableStateOf<Long?>(null) }
     var draggingInventoryOffset by remember { mutableStateOf(Offset.Zero) }
 
     var contextMenuElementId by remember { mutableStateOf<Long?>(null) }
     var contextMenuExpanded by remember { mutableStateOf(false) }
 
+    val lazyList = rememberLazyListState()
+
     Scaffold(
-        modifier = Modifier.onGloballyPositioned { screenWidth = it.size.width.toFloat() },
         topBar = {
             TopAppBar(title = { Text(stringResource(R.string.app_name)) }, actions = {
                 IconButton(onClick = onOpenGameCenter) {
@@ -72,18 +132,19 @@ fun HomeScreen(
             Box(
                 Modifier
                     .fillMaxSize()
+                    .zIndex(if (isDraggingBoardItem) 1f else 0f)
                     .onGloballyPositioned {
                         playAreaOffsetInWindow = it.positionInWindow()
                     }) {
                 activeItems.forEach { item ->
                     key(item.key) {
-                        val density = LocalDensity.current
-                        DraggableElement(item = item, onDragEnd = { finalOffset ->
-                            val limit = with(density) {
-                                screenWidth - panelWidth - 72.dp.toPx()
-                            }
-                            // DELETION: Triggered if any part of the item touches the sidebar.
-                            if (finalOffset.x > limit) {
+                        DraggableElement(item = item, onDragStart = {
+                            isDraggingBoardItem = true
+                        }, onDragEnd = { finalOffset ->
+                            isDraggingBoardItem = false
+                            val limitY = bottomBarTopInWindow - playAreaOffsetInWindow.y - 48f
+                            // DELETION: Triggered if any part of the item touches the bottom bar
+                            if (finalOffset.y > limitY) {
                                 viewModel.removeElement(item.key)
                             } else {
                                 viewModel.updateElementPosition(item.key, finalOffset)
@@ -97,66 +158,154 @@ fun HomeScreen(
                 }
             }
 
-            // 2. SIDE PANEL (Overlay)
-            Surface(
+            // 2. BOTTOM PANEL OVERLAY
+            Column(
                 modifier = Modifier
-                    .fillMaxHeight()
-                    .width(140.dp)
-                    .align(Alignment.CenterEnd)
-                    .onGloballyPositioned { panelWidth = it.size.width.toFloat() },
-                tonalElevation = 8.dp,
-                color = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.9f)
+                    .align(Alignment.BottomCenter)
+                    .padding(8.dp)
+                    .height(192.dp)
+                    .fillMaxWidth(),
+                horizontalAlignment = Alignment.Start,
+                verticalArrangement = Arrangement.spacedBy(2.dp)
             ) {
-                LazyColumn(
-                    contentPadding = PaddingValues(16.dp),
-                    verticalArrangement = Arrangement.spacedBy(16.dp),
-                    horizontalAlignment = Alignment.CenterHorizontally
+                Row(
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = Alignment.CenterVertically,
+                    modifier = Modifier.fillMaxWidth()
                 ) {
-                    items(availableItems, key = { it.id }) { item ->
-                        var itemPosInWindow by remember { mutableStateOf(Offset.Zero) }
+                    // 2.1 FILTER CHIPS
+                    Row(
+                        horizontalArrangement = Arrangement.spacedBy(8.dp)
+                    ) {
+                        val filters = listOf("A - F", "G - J", "K - Z")
+                        filters.forEach { filter ->
+                            FilterChip(
+                                selected = activeFilter == filter && activeCustomFilter == null,
+                                onClick = {
+                                    activeCustomFilter = null
+                                    activeFilter = if (activeFilter == filter) null else filter
+                                },
+                                label = { Text(filter) }
+                            )
+                        }
+                        InputFilterChip(
+                            selected = activeCustomFilter != null,
+                            value = activeCustomFilter ?: "",
+                            onValueChange = { activeFilter = null; activeCustomFilter = it }
+                        )
+                    }
 
-                        Column(
-                            horizontalAlignment = Alignment.CenterHorizontally,
-                            modifier = Modifier
-                                .onGloballyPositioned {
-                                    itemPosInWindow = it.positionInWindow()
-                                }
-                                .pointerInput(item.id) {
-                                    detectDragGestures(onDragStart = { startOffset ->
-                                        draggingInventoryId = item.id
-                                        val fingerInWindow = itemPosInWindow + startOffset
-                                        draggingInventoryOffset = Offset(
-                                            x = fingerInWindow.x - playAreaOffsetInWindow.x - 100f,
-                                            y = fingerInWindow.y - playAreaOffsetInWindow.y - 100f
-                                        )
-                                    }, onDrag = { change, dragAmount ->
-                                        change.consume()
-                                        draggingInventoryOffset += dragAmount
-                                    }, onDragEnd = {
-                                        // Final Check: Drop it if it's clear of the sidebar.
-                                        if (draggingInventoryOffset.x < (screenWidth - panelWidth - 72f)) {
-                                            viewModel.placeElement(item.id, draggingInventoryOffset)
-                                        }
-                                        draggingInventoryId = null
-                                    }, onDragCancel = {
-                                        draggingInventoryId = null
-                                    })
-                                }) {
+                    // 2.2 INVENTORY COUNT (discovered / total)
+                    Text(
+                        stringResource(
+                            R.string.counter, availableItems.size, allItems.size
+                        ),
+                        style = MaterialTheme.typography.labelSmall
+                    )
+                }
+
+                Surface(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .onGloballyPositioned {
+                            bottomBarTopInWindow = it.positionInWindow().y
+                        },
+                    shape = RoundedCornerShape(16.dp),
+                    tonalElevation = 8.dp,
+                    color = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.8f)
+                ) {
+                    Crossfade(
+                        targetState = isDraggingBoardItem,
+                        label = "bottom_bar_crossfade"
+                    ) { isDragging ->
+                        if (isDragging) {
                             Box(
-                                Modifier
-                                    .size(64.dp)
-                                    .clip(RoundedCornerShape(8.dp))
-                                    .combinedClickable(onLongClick = {
-                                        contextMenuElementId = item.id
-                                        contextMenuExpanded = true
-                                    }, onClick = {})) { DynamicAlchemyIcon(item.id) }
-                            Text(item.name ?: "", fontSize = 10.sp)
+                                modifier = Modifier
+                                    .fillMaxSize()
+                                    .background(MaterialTheme.colorScheme.errorContainer),
+                                contentAlignment = Alignment.Center
+                            ) {
+                                Icon(
+                                    painterResource(id = android.R.drawable.ic_delete),
+                                    contentDescription = "Delete",
+                                    tint = MaterialTheme.colorScheme.onErrorContainer,
+                                    modifier = Modifier.size(48.dp)
+                                )
+                            }
+                        } else {
+                            LazyRow(
+                                state = lazyList,
+                                contentPadding = PaddingValues(16.dp),
+                                horizontalArrangement = Arrangement.spacedBy(16.dp),
+                                verticalAlignment = Alignment.CenterVertically,
+                                modifier = Modifier.fillMaxSize()
+                            ) {
+                                items(displayItems, key = { it.id }) { item ->
+                                    var itemPosInWindow by remember { mutableStateOf(Offset.Zero) }
+
+                                    Column(
+                                        horizontalAlignment = Alignment.CenterHorizontally,
+                                        modifier = Modifier
+                                            .onGloballyPositioned {
+                                                itemPosInWindow = it.positionInWindow()
+                                            }
+                                            .pointerInput(item.id) {
+                                                detectDragGestures(onDragStart = { startOffset ->
+                                                    draggingInventoryId = item.id
+                                                    val fingerInWindow =
+                                                        itemPosInWindow + startOffset
+                                                    draggingInventoryOffset = Offset(
+                                                        x = fingerInWindow.x - playAreaOffsetInWindow.x - 100f,
+                                                        y = fingerInWindow.y - playAreaOffsetInWindow.y - 100f
+                                                    )
+                                                }, onDrag = { change, dragAmount ->
+                                                    change.consume()
+                                                    draggingInventoryOffset += dragAmount
+                                                }, onDragEnd = {
+                                                    // Final Check: Drop it if it's clear of the bottom bar
+                                                    val limitY =
+                                                        bottomBarTopInWindow - playAreaOffsetInWindow.y - 48f
+                                                    if (draggingInventoryOffset.y < limitY) {
+                                                        viewModel.placeElement(
+                                                            item.id, draggingInventoryOffset
+                                                        )
+                                                    }
+                                                    draggingInventoryId = null
+                                                }, onDragCancel = {
+                                                    draggingInventoryId = null
+                                                })
+                                            }) {
+                                        Box(
+                                            Modifier
+                                                .size(64.dp)
+                                                .clip(RoundedCornerShape(8.dp))
+                                                .combinedClickable(onLongClick = {
+                                                    contextMenuElementId = item.id
+                                                    contextMenuExpanded = true
+                                                }, onClick = {})
+                                        ) {
+                                            DynamicAlchemyIcon(item.id)
+                                            if (item.final) {
+                                                Icon(
+                                                    painterResource(id = android.R.drawable.star_on),
+                                                    contentDescription = "Final Item",
+                                                    tint = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.8f),
+                                                    modifier = Modifier
+                                                        .size(24.dp)
+                                                        .align(Alignment.BottomEnd)
+                                                )
+                                            }
+                                        }
+                                        Text(item.name, fontSize = 10.sp)
+                                    }
+                                }
+                            }
                         }
                     }
                 }
             }
 
-            // 3. GLOBAL DRAG OVERLAY
+            // 3. GLOBAL DRAG OVERLAY (item being pulled out of the bottom bar)
             draggingInventoryId?.let { id ->
                 Box(Modifier
                     .offset {
@@ -165,7 +314,8 @@ fun HomeScreen(
                             draggingInventoryOffset.y.roundToInt()
                         )
                     }
-                    .size(72.dp)) { DynamicAlchemyIcon(id) }
+                    .size(72.dp)
+                ) { DynamicAlchemyIcon(id) }
             }
         }
 
@@ -185,8 +335,70 @@ fun HomeScreen(
 }
 
 @Composable
+fun InputFilterChip(selected: Boolean, value: String, onValueChange: (String?) -> Unit) {
+    var isEditing by remember { mutableStateOf(false) }
+    val focusRequester = remember { FocusRequester() }
+
+    FilterChip(
+        selected = selected,
+        onClick = {
+            if (selected) onValueChange(null) else isEditing = true
+        },
+        label = {
+            Box {
+                if (isEditing) {
+                    LaunchedEffect(Unit) {
+                        focusRequester.requestFocus()
+                    }
+                    BasicTextField(
+                        cursorBrush = SolidColor(MaterialTheme.colorScheme.onSurface),
+                        value = value,
+                        keyboardOptions = KeyboardOptions.Default.copy(
+                            capitalization = KeyboardCapitalization.Characters,
+                            autoCorrectEnabled = false,
+                            imeAction = ImeAction.Done
+                        ),
+                        keyboardActions = KeyboardActions(
+                            onDone = {
+                                if (value.trim().isEmpty()) {
+                                    onValueChange(null)
+                                } else {
+                                    val lastChar = value.last()
+                                    if (lastChar.isLetter()) {
+                                        val letter = lastChar.uppercaseChar().toString()
+                                        onValueChange(letter)
+                                    }
+                                }
+                                isEditing = false
+                            }
+                        ),
+                        onValueChange = { newValue ->
+                            if (newValue.trim().isEmpty()) {
+                                onValueChange(null)
+                                isEditing = false
+                            } else {
+                                val lastChar = newValue.last()
+                                if (lastChar.isLetter()) {
+                                    val letter = lastChar.uppercaseChar().toString()
+                                    onValueChange(letter)
+                                    isEditing = false
+                                }
+                            }
+                        },
+                        modifier = Modifier.focusRequester(focusRequester)
+                    )
+                } else {
+                    Text(if (value.isEmpty()) "Custom" else value.uppercase())
+                }
+            }
+        }
+    )
+}
+
+@Composable
 fun DraggableElement(
     item: PlacedItem,
+    onDragStart: () -> Unit,
     onDragEnd: (Offset) -> Unit,
     onLongClick: () -> Unit
 ) {
@@ -200,9 +412,14 @@ fun DraggableElement(
             .size(72.dp)
             .combinedClickable(onLongClick = onLongClick, onClick = {})
             .pointerInput(item.key) {
-                detectDragGestures(onDrag = { change, dragAmount ->
-                    change.consume()
-                    currentOffset += dragAmount
-                }, onDragEnd = { onDragEnd(currentOffset) })
+                detectDragGestures(
+                    onDragStart = { _ -> onDragStart() },
+                    onDrag = { change, dragAmount ->
+                        change.consume()
+                        currentOffset += dragAmount
+                    },
+                    onDragEnd = { onDragEnd(currentOffset) },
+                    onDragCancel = { onDragEnd(currentOffset) }
+                )
             }) { DynamicAlchemyIcon(item.id) }
 }

--- a/games/alchemist/src/main/java/com/vayunmathur/games/alchemist/ui/ItemDetails.kt
+++ b/games/alchemist/src/main/java/com/vayunmathur/games/alchemist/ui/ItemDetails.kt
@@ -1,28 +1,243 @@
 package com.vayunmathur.games.alchemist.ui
 
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
 import com.vayunmathur.games.alchemist.R
 import com.vayunmathur.games.alchemist.Route
+import com.vayunmathur.games.alchemist.data.AlchemyRecipe
+import com.vayunmathur.games.alchemist.util.AlchemistViewModel
 import com.vayunmathur.library.ui.IconNavigation
 import com.vayunmathur.library.util.DataStoreUtils
 import com.vayunmathur.library.util.NavBackStack
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun ItemDetailsScreen(backStack: NavBackStack<Route>, ds: DataStoreUtils, itemId: Int) {
-    Scaffold(topBar = {
-        TopAppBar({Text(stringResource(R.string.item_details))}, navigationIcon = { IconNavigation(backStack) })
-    }) { paddingValues ->
-        Column(Modifier.padding(paddingValues)) {
+fun ItemDetailsScreen(
+    backStack: NavBackStack<Route>,
+    @Suppress("UNUSED_PARAMETER") ds: DataStoreUtils,
+    viewModel: AlchemistViewModel,
+    itemId: Int
+) {
+    val allItems by viewModel.allItems.collectAsState()
+    val recipes by viewModel.recipes.collectAsState()
+    val itemsIds by viewModel.itemIds.collectAsState()
 
+    val item = remember(allItems, itemId) { allItems.firstOrNull { it.id == itemId.toLong() } }
+
+    Scaffold(topBar = {
+        TopAppBar(
+            { Text(stringResource(R.string.item_details)) },
+            navigationIcon = { IconNavigation(backStack) }
+        )
+    }) { paddingValues ->
+        if (item == null) {
+            // Catalog not yet loaded or item id unknown — render an empty surface
+            // rather than crashing.
+            Column(Modifier.padding(paddingValues)) {}
+            return@Scaffold
+        }
+
+        Column(
+            Modifier
+                .padding(paddingValues)
+                .padding(8.dp)
+        ) {
+            Card(
+                modifier = Modifier.fillMaxSize(),
+                shape = RoundedCornerShape(16.dp),
+                colors = CardDefaults.cardColors(
+                    containerColor = MaterialTheme.colorScheme.primaryContainer,
+                    contentColor = MaterialTheme.colorScheme.onPrimaryContainer
+                ),
+                elevation = CardDefaults.cardElevation(defaultElevation = 8.dp)
+            ) {
+                Row(
+                    modifier = Modifier.padding(16.dp),
+                    verticalAlignment = Alignment.Top,
+                    horizontalArrangement = Arrangement.spacedBy(16.dp)
+                ) {
+                    Box(
+                        modifier = Modifier.size(40.dp),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        DynamicAlchemyIcon(
+                            iconId = itemId.toLong(),
+                            modifier = Modifier.fillMaxSize()
+                        )
+                    }
+
+                    Column(
+                        modifier = Modifier
+                            .weight(1f)
+                            .align(Alignment.CenterVertically),
+                    ) {
+                        Text(
+                            text = item.name,
+                            style = MaterialTheme.typography.titleMedium,
+                            fontWeight = FontWeight.Bold
+                        )
+                        Text(
+                            text = "ID: #${item.id}",
+                            style = MaterialTheme.typography.labelMedium
+                        )
+                    }
+                }
+
+                LazyColumn(
+                    modifier = Modifier.padding(8.dp, 0.dp),
+                    verticalArrangement = Arrangement.spacedBy(8.dp)
+                ) {
+                    // all recipes that have this item as an output
+                    val makeThis = recipes.filter { item.id in it.outputs }
+                    stickyHeader {
+                        SectionHeader(stringResource(R.string.recipes, makeThis.size))
+                    }
+                    items(makeThis.size) { index ->
+                        RecipeCard(makeThis[index], isItemDiscovered = { id -> id in itemsIds })
+                    }
+
+                    // all recipes that have this item as an input
+                    val whereIHaveInput = recipes.filter { item.id in it.inputs }
+                    val showers = whereIHaveInput.filter { r -> r.outputs.all { it in itemsIds } }
+                    val locked = whereIHaveInput.count { r -> r.outputs.all { it !in itemsIds } }
+                    stickyHeader {
+                        SectionHeader(stringResource(R.string.used_in, whereIHaveInput.size))
+                    }
+                    items(showers.size) { index ->
+                        RecipeCard(showers[index], isItemDiscovered = { id -> id in itemsIds })
+                    }
+                    if (locked > 0) {
+                        item {
+                            RecipeCard(
+                                AlchemyRecipe(emptyList(), emptyList()),
+                                { false },
+                                lockedCount = locked
+                            )
+                        }
+                    }
+                    item {
+                        Spacer(modifier = Modifier.height(8.dp))
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun SectionHeader(text: String) {
+    Box(Modifier.padding(2.dp, 2.dp)) {
+        Text(
+            text = text,
+            style = MaterialTheme.typography.labelMedium,
+            fontWeight = FontWeight.Bold,
+            color = MaterialTheme.colorScheme.primaryContainer,
+            modifier = Modifier
+                .background(
+                    MaterialTheme.colorScheme.onPrimaryContainer,
+                    shape = RoundedCornerShape(8.dp)
+                )
+                .padding(4.dp)
+        )
+    }
+}
+
+@Composable
+fun RecipeCard(
+    recipe: AlchemyRecipe,
+    isItemDiscovered: (Long) -> Boolean = { true },
+    lockedCount: Int = -1
+) {
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(12.dp),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.secondaryContainer,
+            contentColor = MaterialTheme.colorScheme.onSecondaryContainer
+        ),
+        elevation = CardDefaults.cardElevation(defaultElevation = 4.dp)
+    ) {
+        Row(
+            modifier = Modifier.padding(16.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            if (lockedCount > 0) {
+                Column {
+                    Text(
+                        stringResource(R.string.locked, lockedCount),
+                        style = MaterialTheme.typography.bodyMedium,
+                        fontWeight = FontWeight.Bold
+                    )
+                    Text(
+                        stringResource(R.string.locked_description),
+                        style = MaterialTheme.typography.labelMedium,
+                        color = MaterialTheme.colorScheme.onSecondaryContainer.copy(alpha = 0.7f)
+                    )
+                }
+                return@Card
+            }
+
+            recipe.inputs.forEach { inputId ->
+                DynamicAlchemyIcon(
+                    iconId = inputId,
+                    undiscovered = !isItemDiscovered(inputId),
+                    modifier = Modifier.size(32.dp)
+                )
+                if (inputId != recipe.inputs.last()) {
+                    Text(
+                        "+",
+                        style = MaterialTheme.typography.bodyMedium,
+                        fontWeight = FontWeight.Bold
+                    )
+                }
+            }
+            Text(
+                "=",
+                style = MaterialTheme.typography.bodyMedium,
+                fontWeight = FontWeight.Bold
+            )
+            recipe.outputs.forEach { outputId ->
+                DynamicAlchemyIcon(
+                    iconId = outputId,
+                    undiscovered = !isItemDiscovered(outputId),
+                    modifier = Modifier.size(32.dp)
+                )
+                if (outputId != recipe.outputs.last()) {
+                    Text(
+                        "+",
+                        style = MaterialTheme.typography.bodyMedium,
+                        fontWeight = FontWeight.Bold
+                    )
+                }
+            }
         }
     }
 }

--- a/games/alchemist/src/main/java/com/vayunmathur/games/alchemist/ui/Notification.kt
+++ b/games/alchemist/src/main/java/com/vayunmathur/games/alchemist/ui/Notification.kt
@@ -1,0 +1,91 @@
+package com.vayunmathur.games.alchemist.ui
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.slideInVertically
+import androidx.compose.animation.slideOutVertically
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.vayunmathur.games.alchemist.data.AlchemyItem
+
+@Composable
+fun UnlockNotification(
+    unlock: List<AlchemyItem>,
+    showing: Boolean
+) {
+    AnimatedVisibility(
+        visible = showing && unlock.isNotEmpty(),
+        enter = slideInVertically { -it } + fadeIn(),
+        exit = slideOutVertically { -it } + fadeOut(),
+        modifier = Modifier.padding(16.dp)
+    ) {
+        if (unlock.isEmpty()) return@AnimatedVisibility
+        Card(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(top = 24.dp),
+            shape = RoundedCornerShape(16.dp),
+            colors = CardDefaults.cardColors(
+                containerColor = MaterialTheme.colorScheme.primaryContainer,
+                contentColor = MaterialTheme.colorScheme.onPrimaryContainer
+            ),
+            elevation = CardDefaults.cardElevation(defaultElevation = 8.dp)
+        ) {
+            Row(
+                modifier = Modifier.padding(16.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Box(
+                    modifier = Modifier.size(40.dp),
+                    contentAlignment = Alignment.Center
+                ) {
+                    DynamicAlchemyIcon(
+                        iconId = unlock[0].id,
+                        modifier = Modifier.fillMaxSize()
+                    )
+                    if (unlock.size > 1) {
+                        DynamicAlchemyIcon(
+                            iconId = unlock[1].id,
+                            modifier = Modifier
+                                .size(24.dp)
+                                .align(Alignment.BottomEnd)
+                        )
+                    }
+                }
+
+                Column(
+                    modifier = Modifier
+                        .padding(start = 16.dp)
+                        .weight(1f)
+                ) {
+                    Text(
+                        text = if (unlock.size == 1) "Item discovered!" else "${unlock.size} items discovered!",
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = 0.7f)
+                    )
+                    Text(
+                        text = if (unlock.size == 1) unlock[0].name else unlock.joinToString { it.name },
+                        style = MaterialTheme.typography.titleMedium,
+                        fontWeight = FontWeight.Bold
+                    )
+                }
+            }
+        }
+    }
+}

--- a/games/alchemist/src/main/java/com/vayunmathur/games/alchemist/util/AlchemistViewModel.kt
+++ b/games/alchemist/src/main/java/com/vayunmathur/games/alchemist/util/AlchemistViewModel.kt
@@ -10,9 +10,12 @@ import com.vayunmathur.games.alchemist.data.AlchemyRecipe
 import com.vayunmathur.library.util.AchievementsManager
 import com.vayunmathur.library.util.DataStoreUtils
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.first
@@ -64,6 +67,10 @@ class AlchemistViewModel(application: Application) : AndroidViewModel(applicatio
     // --- Placed elements on the play area (committed positions) ---
     private val _placedElements = MutableStateFlow<List<PlacedItem>>(emptyList())
     val placedElements: StateFlow<List<PlacedItem>> = _placedElements.asStateFlow()
+
+    // --- One-shot events for newly-discovered items (drives the unlock toast) ---
+    private val _newUnlocksEvent = MutableSharedFlow<List<AlchemyItem>>(extraBufferCapacity = 5)
+    val newUnlocksEvent: SharedFlow<List<AlchemyItem>> = _newUnlocksEvent.asSharedFlow()
 
     init {
         // Load JSON synchronously so other consumers (e.g. AlchemistAchievementsManager
@@ -131,6 +138,17 @@ class AlchemistViewModel(application: Application) : AndroidViewModel(applicatio
         val toAdd = recipe.outputs.map { PlacedItem(it, target.offset) }
         _placedElements.update { list ->
             list.filterNot { it.key in toRemoveKeys } + toAdd
+        }
+
+        // Emit the new-discovery toast for any outputs not already in the
+        // inventory, then persist all outputs.
+        val knownIds = itemIds.value
+        val discovered = recipe.outputs
+            .filter { it !in knownIds }
+            .distinct()
+            .mapNotNull { id -> _allItems.value.find { it.id == id } }
+        if (discovered.isNotEmpty()) {
+            _newUnlocksEvent.tryEmit(discovered)
         }
         toAdd.forEach { unlockItem(it.id) }
     }

--- a/games/alchemist/src/main/res/values/strings.xml
+++ b/games/alchemist/src/main/res/values/strings.xml
@@ -3,4 +3,9 @@
     <string name="alchemy_icon_content_description">Alchemy Icon %1$d</string>
     <string name="see_details">See details</string>
     <string name="item_details">Item Details</string>
+    <string name="counter">%1$d / %2$d</string>
+    <string name="recipes">Recipes (%1$d)</string>
+    <string name="used_in">Used in (%1$d)</string>
+    <string name="locked">+ %1$d locked recipes.</string>
+    <string name="locked_description">Unlock all outputs of these recipes to see them.</string>
 </resources>


### PR DESCRIPTION
# marked as draft due to bug. see below.
this PR also updates `library/util/Navigation.kt` due to a weird bug with IME padding, hence why the PR is a draft.

i have tried messing around with removing `.imePadding()` from the modifiers list, as well as attempting to consume it before getting to alchemist's `HomeScreen.kt`, but no matter what I do it either results in the `HomeScreen.kt`'s first box (in the scaffold) either not moving up enough or moving up too much.

the red background is applied to alchemist's `HomeScreen.kt`'s first box, as a way of demonstrasting what is happening.

| Image | Description |
|-|-|
| <img width="25%" height="25%" alt="Screenshot_20260522-182435_Alchemist" src="https://github.com/user-attachments/assets/dfb3e6c4-ef74-472c-8d0a-4508bebafd4e" /> | This is what happens already by default. |
| <img width="25%" height="25%" alt="Screenshot_20260522-182427_Alchemist" src="https://github.com/user-attachments/assets/deda79c3-82d4-4440-9559-6ac7f645292c" /> | This is what I want to happen instead. You can actually get this to happen by turning your phone's screen off, then turning it on and unlocking the device. No idea why it fixes after doing this. |

edit: still can't fix this bug - this is why i hate compose so much 🥀 