### PR TITLE
alchemist: add double tap to duplicate element

### DIFF
--- a/games/alchemist/src/main/java/com/vayunmathur/games/alchemist/ui/HomeScreen.kt
+++ b/games/alchemist/src/main/java/com/vayunmathur/games/alchemist/ui/HomeScreen.kt
@@ -4,6 +4,7 @@ import androidx.compose.animation.Crossfade
 import androidx.compose.foundation.background
 import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.gestures.detectDragGestures
+import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -153,6 +154,8 @@ fun HomeScreen(
                         }, onLongClick = {
                             contextMenuElementId = item.id
                             contextMenuExpanded = true
+                        }, onDoubleTap = {
+                            viewModel.duplicateElement(item.key)
                         })
                     }
                 }
@@ -400,7 +403,8 @@ fun DraggableElement(
     item: PlacedItem,
     onDragStart: () -> Unit,
     onDragEnd: (Offset) -> Unit,
-    onLongClick: () -> Unit
+    onLongClick: () -> Unit,
+    onDoubleTap: () -> Unit
 ) {
     var currentOffset by remember(item.key) { mutableStateOf(item.offset) }
 
@@ -411,6 +415,9 @@ fun DraggableElement(
             }
             .size(72.dp)
             .combinedClickable(onLongClick = onLongClick, onClick = {})
+            .pointerInput(item.key) {
+                detectTapGestures(onDoubleTap = { onDoubleTap() })
+            }
             .pointerInput(item.key) {
                 detectDragGestures(
                     onDragStart = { _ -> onDragStart() },

--- a/games/alchemist/src/main/java/com/vayunmathur/games/alchemist/util/AlchemistViewModel.kt
+++ b/games/alchemist/src/main/java/com/vayunmathur/games/alchemist/util/AlchemistViewModel.kt
@@ -119,6 +119,17 @@ class AlchemistViewModel(application: Application) : AndroidViewModel(applicatio
         _placedElements.update { list -> list.filterNot { it.key == key } }
     }
 
+    /** Duplicate a placed element at a slightly offset position. */
+    fun duplicateElement(key: Long) {
+        val current = _placedElements.value
+        val elementToDuplicate = current.find { it.key == key } ?: return
+        val duplicatedItem = PlacedItem(
+            id = elementToDuplicate.id,
+            offset = elementToDuplicate.offset + Offset(25f, 25f)
+        )
+        _placedElements.update { it + duplicatedItem }
+    }
+
     /**
      * Test the moved element against the other placed elements for a recipe match.
      * If found, removes the two inputs, adds the outputs at the target's position,

--- a/library/src/main/java/com/vayunmathur/library/ui/Modifier.kt
+++ b/library/src/main/java/com/vayunmathur/library/ui/Modifier.kt
@@ -1,6 +1,17 @@
 package com.vayunmathur.library.ui
 
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.Modifier
 
 fun Modifier.invisibleClickable(onClick: () -> Unit) = clickable(null, null) {onClick()}
+
+/**
+ * Adds a double-tap handler to this modifier.
+ * Usage: `Modifier.onDoubleTap { /* duplicate item in viewmodel/state */ }`
+ */
+fun Modifier.onDoubleTap(onDoubleTap: () -> Unit): Modifier =
+	this.pointerInput(Unit) {
+		detectTapGestures(onDoubleTap = { onDoubleTap() })
+	}


### PR DESCRIPTION
Hello. I really liked the alchemist app but found it tiresome to constantly look for an element I just used. I added a feature where you can double tap an element to duplicate it. If this is not a feature you're interested in adding that's okay, I'll just use it for myself. Thanks for the app!

https://github.com/user-attachments/assets/8222ed60-9f1c-47d3-a323-9d16ed09d3e9

