### PR TITLE
chess: drive win achievements off game result, not localized text

### DIFF
--- a/games/chess/build.gradle.kts
+++ b/games/chess/build.gradle.kts
@@ -22,4 +22,5 @@ android {
 }
 
 dependencies {
+    testImplementation("junit:junit:4.13.2")
 }

--- a/games/chess/src/main/java/com/vayunmathur/games/chess/MainActivity.kt
+++ b/games/chess/src/main/java/com/vayunmathur/games/chess/MainActivity.kt
@@ -60,6 +60,7 @@ import com.vayunmathur.library.util.DataStoreUtils
 import com.vayunmathur.games.chess.util.ChessViewModel
 import com.vayunmathur.games.chess.util.ChessUiState
 import com.vayunmathur.games.chess.util.GameMode
+import com.vayunmathur.games.chess.util.GameResult
 import com.vayunmathur.games.chess.util.StockfishEngine
 import com.vayunmathur.games.chess.data.Piece
 import com.vayunmathur.games.chess.data.PieceColor
@@ -254,13 +255,14 @@ fun ChessGame(
         }
     }
 
-    LaunchedEffect(uiState.gameStatus) {
-        val status = uiState.gameStatus ?: return@LaunchedEffect
+    LaunchedEffect(uiState.gameResult) {
+        // Drive achievements off the typed game result, not the localized status text, so they
+        // work in every locale. Only a checkmate counts as a "win"; draws unlock nothing here.
+        val result = uiState.gameResult as? GameResult.Checkmate ?: return@LaunchedEffect
         val mode = uiState.gameMode
-        val playerWins = if (mode is GameMode.VsAI) {
-            if (mode.playerColor == PieceColor.WHITE) status.contains("White wins") else status.contains("Black wins")
-        } else {
-            status.contains("wins")
+        val playerWins = when (mode) {
+            is GameMode.VsAI -> result.winner == mode.playerColor
+            GameMode.TwoPlayer -> true // local play: the side that delivered mate is "the player"
         }
 
         if (playerWins) {

--- a/games/chess/src/main/java/com/vayunmathur/games/chess/data/ChessModel.kt
+++ b/games/chess/src/main/java/com/vayunmathur/games/chess/data/ChessModel.kt
@@ -201,14 +201,45 @@ data class Board(
         }.any { isValidMoveIgnoringCheck(it, kingPos) }
     }
 
-    fun isCheckmate(kingColor: PieceColor): Boolean {
-        if (!isKingInCheck(kingColor)) return false
+    /** True if [color] has at least one legal move (move that doesn't leave its own king in check). */
+    fun hasLegalMoves(color: PieceColor): Boolean {
         return pieces.flatMapIndexed { row, cols ->
             cols.mapIndexedNotNull { col, piece ->
-                if (piece != null && piece.color == kingColor) Position(row, col) else null
+                if (piece != null && piece.color == color) Position(row, col) else null
             }
-        }.none { pos ->
+        }.any { pos ->
             (0..7).any { i -> (0..7).any { j -> isValidMove(pos, Position(i, j)) } }
+        }
+    }
+
+    fun isCheckmate(kingColor: PieceColor): Boolean =
+        isKingInCheck(kingColor) && !hasLegalMoves(kingColor)
+
+    /** Side to move ([color]) is not in check but has no legal move → draw by stalemate. */
+    fun isStalemate(color: PieceColor): Boolean =
+        !isKingInCheck(color) && !hasLegalMoves(color)
+
+    /**
+     * Draw by insufficient mating material: K vs K, K+minor vs K, and K+B vs K+B with the
+     * bishops on same-colour squares. Anything with a pawn/rook/queen, or that could still
+     * force mate (e.g. two bishops, bishop+knight), is not auto-drawn.
+     */
+    fun isInsufficientMaterial(): Boolean {
+        val all = pieces.flatten().filterNotNull()
+        if (all.any { it.type == PieceType.PAWN || it.type == PieceType.ROOK || it.type == PieceType.QUEEN }) {
+            return false
+        }
+        val minors = all.filter { it.type == PieceType.BISHOP || it.type == PieceType.KNIGHT }
+        return when (minors.size) {
+            0, 1 -> true // K vs K, or K + single minor vs K
+            else -> {
+                if (minors.any { it.type == PieceType.KNIGHT }) return false
+                // only bishops left: drawn iff every bishop sits on the same square colour
+                val squareColors = pieces.flatMapIndexed { r, cols ->
+                    cols.mapIndexedNotNull { c, p -> if (p?.type == PieceType.BISHOP) (r + c) % 2 else null }
+                }.toSet()
+                squareColors.size == 1
+            }
         }
     }
 

--- a/games/chess/src/main/java/com/vayunmathur/games/chess/util/ChessApi.kt
+++ b/games/chess/src/main/java/com/vayunmathur/games/chess/util/ChessApi.kt
@@ -5,12 +5,18 @@ import com.vayunmathur.games.chess.data.Position
 import com.vayunmathur.games.chess.data.PieceType
 
 class ChessApi {
-    suspend fun getBestMove(board: Board): Move {
+    /**
+     * Returns the engine's best move, or null when the engine reports it has no move to play
+     * ("bestmove (none)" / "0000" — i.e. the AI is checkmated or stalemated). Callers must treat
+     * null as "no move available" rather than parsing it as a board coordinate.
+     */
+    suspend fun getBestMove(board: Board): Move? {
         StockfishEngine.nextMove(board)
         while (true) {
             val lineSplit = StockfishEngine.outputChannel.receive().split(" ")
             if (lineSplit[0] == "bestmove") {
-                val moveString = lineSplit[1]
+                val moveString = lineSplit.getOrNull(1) ?: return null
+                if (moveString == "(none)" || moveString == "0000" || moveString.length < 4) return null
                 val startPosition = Position(8 - (moveString[1] - '0'), moveString[0] - 'a')
                 val endPosition = Position(8 - (moveString[3] - '0'), moveString[2] - 'a')
                 val promotedTo = when (moveString.getOrNull(4)) {

--- a/games/chess/src/main/java/com/vayunmathur/games/chess/util/ChessViewModel.kt
+++ b/games/chess/src/main/java/com/vayunmathur/games/chess/util/ChessViewModel.kt
@@ -20,12 +20,22 @@ sealed class GameMode {
     data class VsAI(val playerColor: PieceColor, val difficulty: StockfishEngine.Difficulty) : GameMode()
 }
 
+/** Terminal outcome of a game, or null while it is still in progress. */
+sealed class GameResult {
+    data class Checkmate(val winner: PieceColor) : GameResult()
+    data object Stalemate : GameResult()
+    data object InsufficientMaterial : GameResult()
+
+    val isGameOver: Boolean get() = true
+}
+
 data class ChessUiState(
     val board: Board = Board.initialState,
     val selectedPiece: Position? = null,
     val gameMode: GameMode = GameMode.TwoPlayer,
     val turn: PieceColor = PieceColor.WHITE,
     val gameStatus: String? = null,
+    val gameResult: GameResult? = null,
     val isBoardFlipped: Boolean = false
 )
 
@@ -49,7 +59,7 @@ class ChessViewModel(application: Application) : AndroidViewModel(application) {
         val board = state.board
         val pieceAtPosition = board.pieces[position.row][position.col]
 
-        if (isGameOver(board)) return
+        if (state.gameResult != null) return
 
         val mode = state.gameMode
         if (mode is GameMode.VsAI && state.turn != mode.playerColor) return
@@ -62,16 +72,18 @@ class ChessViewModel(application: Application) : AndroidViewModel(application) {
         } else {
             if (board.isValidMove(selectedPiece, position)) {
                 val newBoard = board.movePiece(selectedPiece, position)
+                val nextTurn = if (newBoard.promotionPosition != null) state.turn else state.turn.opposite
+                val (result, status) = statusFor(newBoard, nextTurn)
                 _uiState.update {
-                    val nextTurn = if (newBoard.promotionPosition != null) it.turn else it.turn.opposite
                     it.copy(
                         board = newBoard,
                         selectedPiece = null,
                         turn = nextTurn,
-                        gameStatus = getGameStatus(newBoard, nextTurn)
+                        gameStatus = status,
+                        gameResult = result
                     )
                 }
-                if (mode is GameMode.VsAI && !isGameOver(newBoard) && newBoard.promotionPosition == null) {
+                if (mode is GameMode.VsAI && result == null && newBoard.promotionPosition == null) {
                     viewModelScope.launch {
                         delay(500)
                         makeAiMove()
@@ -87,15 +99,12 @@ class ChessViewModel(application: Application) : AndroidViewModel(application) {
         val board = _uiState.value.board
         val promotionPosition = board.promotionPosition ?: return
         val newBoard = board.promotePawn(promotionPosition, pieceType)
+        val nextTurn = _uiState.value.turn.opposite
+        val (result, status) = statusFor(newBoard, nextTurn)
         _uiState.update {
-            val nextTurn = it.turn.opposite
-            it.copy(
-                board = newBoard,
-                turn = nextTurn,
-                gameStatus = getGameStatus(newBoard, nextTurn)
-            )
+            it.copy(board = newBoard, turn = nextTurn, gameStatus = status, gameResult = result)
         }
-        if (_uiState.value.gameMode is GameMode.VsAI && !isGameOver(newBoard)) {
+        if (_uiState.value.gameMode is GameMode.VsAI && result == null) {
             makeAiMove()
         }
     }
@@ -103,28 +112,38 @@ class ChessViewModel(application: Application) : AndroidViewModel(application) {
     private fun makeAiMove() {
         viewModelScope.launch {
             val board = _uiState.value.board
-            val bestMove = chessApi.getBestMove(board)
+            // Returns null when the engine has no move to make (mate/stalemate against the AI);
+            // without this guard the "bestmove (none)" reply would be parsed as a coordinate and crash.
+            val bestMove = chessApi.getBestMove(board) ?: return@launch
             val newBoard = board.movePiece(bestMove.start, bestMove.end, bestMove.promotedTo)
+            val nextTurn = _uiState.value.turn.opposite
+            val (result, status) = statusFor(newBoard, nextTurn)
             _uiState.update {
-                val nextTurn = it.turn.opposite
-                it.copy(
-                    board = newBoard,
-                    turn = nextTurn,
-                    gameStatus = getGameStatus(newBoard, nextTurn)
-                )
+                it.copy(board = newBoard, turn = nextTurn, gameStatus = status, gameResult = result)
             }
         }
     }
 
-    private fun isGameOver(board: Board): Boolean =
-        board.isCheckmate(PieceColor.WHITE) || board.isCheckmate(PieceColor.BLACK)
+    /** Terminal result for [board] when it is [turn]'s move, or null if play continues. */
+    private fun resultFor(board: Board, turn: PieceColor): GameResult? = when {
+        board.isCheckmate(turn) -> GameResult.Checkmate(turn.opposite)
+        board.isInsufficientMaterial() -> GameResult.InsufficientMaterial
+        board.isStalemate(turn) -> GameResult.Stalemate
+        else -> null
+    }
 
-    private fun getGameStatus(board: Board, turn: PieceColor): String? {
+    /** Computes the result plus the localized status line (terminal result, or "check", or none). */
+    private fun statusFor(board: Board, turn: PieceColor): Pair<GameResult?, String?> {
+        val result = resultFor(board, turn)
         val ctx = getApplication<Application>()
-        return when {
-            board.isCheckmate(turn) -> if (turn == PieceColor.WHITE) ctx.getString(R.string.black_wins) else ctx.getString(R.string.white_wins)
-            board.isKingInCheck(turn) -> ctx.getString(R.string.check)
-            else -> null
+        val text = when (result) {
+            is GameResult.Checkmate ->
+                if (result.winner == PieceColor.WHITE) ctx.getString(R.string.white_wins)
+                else ctx.getString(R.string.black_wins)
+            GameResult.Stalemate -> ctx.getString(R.string.stalemate)
+            GameResult.InsufficientMaterial -> ctx.getString(R.string.draw_insufficient_material)
+            null -> if (board.isKingInCheck(turn)) ctx.getString(R.string.check) else null
         }
+        return result to text
     }
 }

--- a/games/chess/src/main/res/values/strings.xml
+++ b/games/chess/src/main/res/values/strings.xml
@@ -17,6 +17,8 @@
     <string name="checkmate_wins">Checkmate! %1$s wins.</string>
     <string name="white_wins">Checkmate! White wins.</string>
     <string name="black_wins">Checkmate! Black wins.</string>
+    <string name="stalemate">Stalemate! It\'s a draw.</string>
+    <string name="draw_insufficient_material">Draw — insufficient material.</string>
 
     <string name="piece_white_king">White King</string>
     <string name="piece_white_queen">White Queen</string>

--- a/games/chess/src/test/java/com/vayunmathur/games/chess/data/ChessRulesTest.kt
+++ b/games/chess/src/test/java/com/vayunmathur/games/chess/data/ChessRulesTest.kt
@@ -1,0 +1,129 @@
+package com.vayunmathur.games.chess.data
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ChessRulesTest {
+
+    // file 'a'..'h', rank 1..8  ->  internal Position(row, col) where row 0 = rank 8, col 0 = file a
+    private fun sq(file: Char, rank: Int) = Position(8 - rank, file - 'a')
+
+    private fun board(vararg placements: Pair<Position, Piece>): Board {
+        val grid = MutableList(8) { MutableList<Piece?>(8) { null } }
+        for ((pos, piece) in placements) grid[pos.row][pos.col] = piece
+        return Board(grid.map { it.toList() })
+    }
+
+    private fun king(color: PieceColor) = Piece(PieceType.KING, color)
+    private fun queen(color: PieceColor) = Piece(PieceType.QUEEN, color)
+    private fun rook(color: PieceColor) = Piece(PieceType.ROOK, color)
+    private fun bishop(color: PieceColor) = Piece(PieceType.BISHOP, color)
+    private fun knight(color: PieceColor) = Piece(PieceType.KNIGHT, color)
+
+    @Test
+    fun initialPosition_hasLegalMoves_andIsNotTerminal() {
+        val b = Board.initialState
+        assertTrue(b.hasLegalMoves(PieceColor.WHITE))
+        assertFalse(b.isCheckmate(PieceColor.WHITE))
+        assertFalse(b.isStalemate(PieceColor.WHITE))
+        assertFalse(b.isInsufficientMaterial())
+    }
+
+    @Test
+    fun initialPosition_fenIsStandardStartpos() {
+        assertEquals(
+            "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1",
+            Board.initialState.toFen()
+        )
+    }
+
+    @Test
+    fun stalemate_isDetected_andIsNotCheckmate() {
+        // Black king a8 boxed in by White queen b6; Black to move, not in check, no legal move.
+        val b = board(
+            sq('a', 8) to king(PieceColor.BLACK),
+            sq('b', 6) to queen(PieceColor.WHITE),
+            sq('h', 1) to king(PieceColor.WHITE),
+        )
+        assertFalse(b.hasLegalMoves(PieceColor.BLACK))
+        assertTrue(b.isStalemate(PieceColor.BLACK))
+        assertFalse(b.isCheckmate(PieceColor.BLACK))
+    }
+
+    @Test
+    fun checkmate_isDetected_andIsNotStalemate() {
+        // Black king a8 mated by White queen b7 supported by White king c6.
+        val b = board(
+            sq('a', 8) to king(PieceColor.BLACK),
+            sq('b', 7) to queen(PieceColor.WHITE),
+            sq('c', 6) to king(PieceColor.WHITE),
+        )
+        assertTrue(b.isCheckmate(PieceColor.BLACK))
+        assertFalse(b.isStalemate(PieceColor.BLACK))
+        assertFalse(b.hasLegalMoves(PieceColor.BLACK))
+    }
+
+    @Test
+    fun insufficientMaterial_kingVsKing() {
+        val b = board(
+            sq('e', 1) to king(PieceColor.WHITE),
+            sq('e', 8) to king(PieceColor.BLACK),
+        )
+        assertTrue(b.isInsufficientMaterial())
+    }
+
+    @Test
+    fun insufficientMaterial_kingAndMinorVsKing() {
+        val withBishop = board(
+            sq('e', 1) to king(PieceColor.WHITE),
+            sq('c', 1) to bishop(PieceColor.WHITE),
+            sq('e', 8) to king(PieceColor.BLACK),
+        )
+        val withKnight = board(
+            sq('e', 1) to king(PieceColor.WHITE),
+            sq('b', 1) to knight(PieceColor.WHITE),
+            sq('e', 8) to king(PieceColor.BLACK),
+        )
+        assertTrue(withBishop.isInsufficientMaterial())
+        assertTrue(withKnight.isInsufficientMaterial())
+    }
+
+    @Test
+    fun insufficientMaterial_oppositeBishops_sameColorIsDraw_differentColorIsNot() {
+        // c1 is a dark square; f8 is also dark -> same colour bishops -> draw.
+        val sameColor = board(
+            sq('e', 1) to king(PieceColor.WHITE),
+            sq('c', 1) to bishop(PieceColor.WHITE),
+            sq('e', 8) to king(PieceColor.BLACK),
+            sq('f', 8) to bishop(PieceColor.BLACK),
+        )
+        // c1 dark vs c8 light -> different colours -> mate still possible -> not auto-draw.
+        val diffColor = board(
+            sq('e', 1) to king(PieceColor.WHITE),
+            sq('c', 1) to bishop(PieceColor.WHITE),
+            sq('e', 8) to king(PieceColor.BLACK),
+            sq('c', 8) to bishop(PieceColor.BLACK),
+        )
+        assertTrue(sameColor.isInsufficientMaterial())
+        assertFalse(diffColor.isInsufficientMaterial())
+    }
+
+    @Test
+    fun sufficientMaterial_rookOrTwoKnights_isNotDraw() {
+        val withRook = board(
+            sq('e', 1) to king(PieceColor.WHITE),
+            sq('a', 1) to rook(PieceColor.WHITE),
+            sq('e', 8) to king(PieceColor.BLACK),
+        )
+        val twoKnights = board(
+            sq('e', 1) to king(PieceColor.WHITE),
+            sq('b', 1) to knight(PieceColor.WHITE),
+            sq('g', 1) to knight(PieceColor.WHITE),
+            sq('e', 8) to king(PieceColor.BLACK),
+        )
+        assertFalse(withRook.isInsufficientMaterial())
+        assertFalse(twoKnights.isInsufficientMaterial())
+    }
+}


### PR DESCRIPTION
## What
Drive win/achievement detection off the typed game result instead of matching localized status text.

## Why
Achievements compared the **localized** status string against hardcoded English (`status.contains("White wins")`). In the 14 translated locales the comparison never matched, so a win unlocked **no** achievements and never incremented the win counter.

## Changes
- `MainActivity`: read `uiState.gameResult` (a `GameResult.Checkmate`) instead of parsing the status string.

## ⚠️ Stacked on #261
This builds on the typed `GameResult` introduced in #261, so until that merges this PR's diff also includes the draw-detection commit. **Please review/merge #261 first**; this branch will reduce to the single `MainActivity` change once #261 lands.

## Testing
- `:games:chess:compileDebugKotlin` clean.
- Verified live on an emulator: in **Italian** locale a win shows **"Scacco matto! Vince il Nero."** and the achievement still unlocks — the previous English string-match would have silently skipped it. _(Screenshot below.)_
